### PR TITLE
[Feat/frontend]: Implement portfolio page

### DIFF
--- a/apps/web/app/portfolio/page.tsx
+++ b/apps/web/app/portfolio/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useWalletContext } from "@/context/WalletContext";
+import { usePortfolio } from "@/hooks/usePortfolio";
+import { PositionCard } from "@/components/PositionCard";
+import { API_BASE, SWYFT_NETWORK } from "@/lib/constants";
+import { signTransaction } from "@stellar/freighter-api";
+import { buildCollectTx } from "@swyft/sdk";
+import Link from "next/link";
+
+function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("swyft_auth_token");
+}
+
+export default function PortfolioPage() {
+  const router = useRouter();
+  const { address } = useWalletContext();
+  const authToken = getAuthToken();
+  const { active, closed, loading, refresh, totalValueUsd } = usePortfolio(authToken);
+  const [showClosed, setShowClosed] = useState(false);
+  const [collectingId, setCollectingId] = useState<string | null>(null);
+
+  // Redirect if no wallet connected
+  useEffect(() => {
+    if (address === null && !loading) {
+      router.replace("/");
+    }
+  }, [address, loading, router]);
+
+  const handleCollectFees = useCallback(async (positionId: string) => {
+    if (!authToken) return;
+    const position = active.find((p) => p.id === positionId);
+    if (!position) return;
+
+    setCollectingId(positionId);
+    try {
+      const { xdr } = buildCollectTx({
+        positionId: position.id,
+        poolId: position.poolId,
+        ownerAddress: position.ownerWallet,
+      });
+
+      const signResult = await signTransaction(xdr, { network: SWYFT_NETWORK });
+      const signedXdr =
+        typeof signResult === "string"
+          ? signResult
+          : "signedTxXdr" in signResult
+          ? (signResult as { signedTxXdr: string }).signedTxXdr
+          : null;
+
+      if (!signedXdr) return;
+
+      await fetch(`${API_BASE}/transactions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({ xdr: signedXdr }),
+      });
+
+      await refresh();
+    } catch {
+      // silent — user rejected or network error
+    } finally {
+      setCollectingId(null);
+    }
+  }, [authToken, active, refresh]);
+
+  if (!address) return null;
+
+  const positions = showClosed ? [...active, ...closed] : active;
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-10">
+      {/* Summary */}
+      <div className="mb-8 rounded-2xl border border-zinc-200 bg-white px-6 py-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <p className="text-xs text-zinc-400 mb-1">Total portfolio value</p>
+        <p className="text-3xl font-bold text-zinc-900 dark:text-white">
+          ${totalValueUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+        </p>
+        <p className="text-xs text-zinc-400 mt-1">{active.length} active position{active.length !== 1 ? "s" : ""}</p>
+      </div>
+
+      {/* Controls */}
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-base font-semibold text-zinc-900 dark:text-white">
+          {showClosed ? "All positions" : "Active positions"}
+        </h1>
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <span className="text-xs text-zinc-500">Show closed</span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={showClosed}
+            onClick={() => setShowClosed((v) => !v)}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+              showClosed ? "bg-indigo-600" : "bg-zinc-300 dark:bg-zinc-700"
+            }`}
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                showClosed ? "translate-x-4" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </label>
+      </div>
+
+      {/* Loading */}
+      {loading && positions.length === 0 && (
+        <div className="flex justify-center py-20">
+          <span className="h-6 w-6 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent" aria-label="Loading" />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && positions.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+          <p className="text-sm text-zinc-500">No positions yet.</p>
+          <Link
+            href="/pools"
+            className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+          >
+            Browse pools
+          </Link>
+        </div>
+      )}
+
+      {/* Position grid */}
+      {positions.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {positions.map((p) => (
+            <PositionCard
+              key={p.id}
+              position={p}
+              onCollectFees={handleCollectFees}
+              collecting={collectingId === p.id}
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -1,11 +1,17 @@
+import Link from "next/link";
 import { WalletButton } from "@/components/WalletButton";
 
 export function Navbar() {
   return (
     <nav className="sticky top-0 z-40 flex h-16 items-center justify-between border-b border-zinc-200 bg-white/80 px-6 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
-      <span className="text-lg font-bold tracking-tight text-zinc-900 dark:text-white">
-        Swyft
-      </span>
+      <div className="flex items-center gap-6">
+        <Link href="/" className="text-lg font-bold tracking-tight text-zinc-900 dark:text-white">
+          Swyft
+        </Link>
+        <Link href="/portfolio" className="text-sm text-zinc-500 hover:text-zinc-900 dark:hover:text-white transition-colors">
+          Portfolio
+        </Link>
+      </div>
       <WalletButton />
     </nav>
   );

--- a/apps/web/components/PositionCard.tsx
+++ b/apps/web/components/PositionCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { PositionRangeBadge } from "@swyft/ui";
+import type { PositionSnapshot } from "@swyft/ui";
+
+function rangeStatus(p: PositionSnapshot): "in-range" | "out-of-range" | "closed" {
+  if (p.status === "closed") return "closed";
+  const lower = Math.pow(1.0001, p.lowerTick);
+  const upper = Math.pow(1.0001, p.upperTick);
+  return p.poolCurrentPrice >= lower && p.poolCurrentPrice <= upper ? "in-range" : "out-of-range";
+}
+
+function shortSymbol(id: string) {
+  return id.length > 8 ? `${id.slice(0, 4)}…` : id;
+}
+
+interface Props {
+  position: PositionSnapshot;
+  onCollectFees: (id: string) => void;
+  collecting: boolean;
+}
+
+export function PositionCard({ position: p, onCollectFees, collecting }: Props) {
+  const rs = rangeStatus(p);
+  const t0 = shortSymbol(p.token0);
+  const t1 = shortSymbol(p.token1);
+  const lowerPrice = Math.pow(1.0001, p.lowerTick).toFixed(6);
+  const upperPrice = Math.pow(1.0001, p.upperTick).toFixed(6);
+  const fees0 = parseFloat(p.uncollectedFeesToken0);
+  const fees1 = parseFloat(p.uncollectedFeesToken1);
+  const hasFees = fees0 > 0 || fees1 > 0;
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <p className="text-sm font-semibold text-zinc-900 dark:text-white">
+            {t0} / {t1}
+          </p>
+          <p className="text-xs text-zinc-400 mt-0.5">
+            {lowerPrice} – {upperPrice}
+          </p>
+        </div>
+        <PositionRangeBadge status={rs} />
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <div className="rounded-xl bg-zinc-50 dark:bg-zinc-800/50 px-3 py-2.5">
+          <p className="text-xs text-zinc-400 mb-0.5">Value</p>
+          <p className="text-sm font-semibold text-zinc-900 dark:text-white">
+            ${p.currentValueUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+          </p>
+        </div>
+        <div className="rounded-xl bg-indigo-50 dark:bg-indigo-950/30 px-3 py-2.5">
+          <p className="text-xs text-indigo-400 mb-0.5">Uncollected fees</p>
+          <p className="text-xs font-medium text-indigo-700 dark:text-indigo-300 tabular-nums">
+            {fees0.toFixed(4)} {t0}
+          </p>
+          <p className="text-xs font-medium text-indigo-700 dark:text-indigo-300 tabular-nums">
+            {fees1.toFixed(4)} {t1}
+          </p>
+        </div>
+      </div>
+
+      {/* Actions */}
+      {p.status === "active" && (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => onCollectFees(p.id)}
+            disabled={collecting || !hasFees}
+            className="flex-1 rounded-xl bg-indigo-600 py-2 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+          >
+            {collecting ? "Collecting…" : "Collect fees"}
+          </button>
+          <Link
+            href={`/pools/${p.poolId}/add?positionId=${p.id}`}
+            className="flex-1 rounded-xl border border-zinc-200 dark:border-zinc-700 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors text-center"
+          >
+            Add
+          </Link>
+          <Link
+            href={`/positions/${p.id}/remove`}
+            className="flex-1 rounded-xl border border-red-200 dark:border-red-900 py-2 text-xs font-semibold text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950 transition-colors text-center"
+          >
+            Remove
+          </Link>
+        </div>
+      )}
+
+      {p.status === "closed" && p.closedAt && (
+        <p className="text-xs text-zinc-400">
+          Closed {new Date(p.closedAt * 1000).toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/hooks/usePortfolio.ts
+++ b/apps/web/hooks/usePortfolio.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { PositionSnapshot } from "@swyft/ui";
+import { API_BASE } from "@/lib/constants";
+
+async function fetchPositions(
+  authToken: string,
+  status: "active" | "closed"
+): Promise<PositionSnapshot[]> {
+  const res = await fetch(`${API_BASE}/positions?status=${status}`, {
+    headers: { Authorization: `Bearer ${authToken}` },
+  });
+  if (!res.ok) return [];
+  const data = (await res.json()) as { items?: PositionSnapshot[] };
+  return data.items ?? [];
+}
+
+export function usePortfolio(authToken: string | null) {
+  const [active, setActive] = useState<PositionSnapshot[]>([]);
+  const [closed, setClosed] = useState<PositionSnapshot[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!authToken) {
+      setActive([]);
+      setClosed([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const [a, c] = await Promise.all([
+        fetchPositions(authToken, "active"),
+        fetchPositions(authToken, "closed"),
+      ]);
+      setActive(a);
+      setClosed(c);
+    } catch {
+      // keep stale data on error
+    } finally {
+      setLoading(false);
+    }
+  }, [authToken]);
+
+  useEffect(() => {
+    refresh();
+    if (!authToken) return;
+    const id = setInterval(refresh, 30_000);
+    return () => clearInterval(id);
+  }, [authToken, refresh]);
+
+  const totalValueUsd = active.reduce((sum, p) => sum + p.currentValueUsd, 0);
+
+  return { active, closed, loading, refresh, totalValueUsd };
+}


### PR DESCRIPTION
closes #62 



This PR adds the /portfolio page as the central hub for liquidity providers to manage and monitor their positions across pools.

Changes:
Added /portfolio route with wallet authentication guard (redirects home if no wallet is connected)
Integrated GET /positions to fetch wallet-specific LP positions
Added position cards showing:
Pool token pair
Price range
Current liquidity value (USD)
Uncollected fees
In-range / out-of-range status badge
Added Collect fees action flow
Added Remove navigation to remove liquidity flow
Added Add navigation to add liquidity flow for the same pool
Implemented toggle for viewing closed positions with historical data
Added empty state with CTA to browse pools when no positions exist
Added total portfolio value summary at the top
Enabled automatic refresh of position values and fees every 30 seconds