### PR TITLE
feat: improve TypeScript types in router contract (#146)

### DIFF
--- a/packages/contracts/router/src/lib.rs
+++ b/packages/contracts/router/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
 
 #[cfg(test)]
 extern crate std;
@@ -8,29 +8,68 @@ extern crate std;
 #[cfg(test)]
 mod test;
 
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RouterError {
+    /// The swap deadline has passed.
+    DeadlineExpired = 1,
+    /// The amount provided is zero or negative.
+    InvalidAmount = 2,
+    /// The swap path contains fewer than two tokens.
+    InvalidPath = 3,
+    /// No pool rate has been registered for this token pair.
+    PoolNotFound = 4,
+    /// The output amount fell below the caller's minimum (slippage).
+    SlippageExceeded = 5,
+    /// The input amount exceeded the caller's maximum (slippage).
+    ExcessiveInput = 6,
+    /// An arithmetic overflow occurred during the swap calculation.
+    Overflow = 7,
+}
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Pool(Address, Address),
 }
 
+// ── Events ────────────────────────────────────────────────────────────────────
+
+/// Emitted after every successful swap hop.
 #[contracttype]
 #[derive(Clone)]
 pub struct SwapEvent {
+    /// Token sold by the caller.
     pub token_in: Address,
+    /// Token received by the caller.
     pub token_out: Address,
+    /// Exact amount of `token_in` consumed.
     pub amount_in: i128,
+    /// Exact amount of `token_out` produced.
     pub amount_out: i128,
 }
+
+// ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
 pub struct Router;
 
 #[contractimpl]
 impl Router {
+    /// Register or update the exchange rate for a token pair.
+    ///
+    /// # Arguments
+    /// * `token_in`  - Address of the input token.
+    /// * `token_out` - Address of the output token.
+    /// * `rate`      - Units of `token_out` per unit of `token_in`. Must be > 0.
     pub fn set_pool_rate(env: Env, token_in: Address, token_out: Address, rate: i128) {
         if rate <= 0 {
-            panic!("invalid pool rate");
+            panic_with_error!(&env, RouterError::InvalidAmount);
         }
 
         env.storage()
@@ -38,6 +77,17 @@ impl Router {
             .set(&DataKey::Pool(token_in, token_out), &rate);
     }
 
+    /// Swap an exact amount of `token_in` for at least `min_amount_out` of `token_out`.
+    ///
+    /// # Arguments
+    /// * `token_in`      - Address of the token being sold.
+    /// * `token_out`     - Address of the token being bought.
+    /// * `amount_in`     - Exact amount of `token_in` to sell. Must be > 0.
+    /// * `min_amount_out`- Minimum acceptable output (slippage guard).
+    /// * `deadline`      - Unix timestamp after which the transaction reverts.
+    ///
+    /// # Returns
+    /// The actual amount of `token_out` received.
     pub fn exact_input_single(
         env: Env,
         token_in: Address,
@@ -47,16 +97,27 @@ impl Router {
         deadline: u64,
     ) -> i128 {
         ensure_deadline(&env, deadline);
-        ensure_positive_amount(amount_in);
+        ensure_positive_amount(&env, amount_in);
 
         let amount_out = execute_exact_input_hop(&env, token_in, token_out, amount_in);
         if amount_out < min_amount_out {
-            panic!("slippage breach");
+            panic_with_error!(&env, RouterError::SlippageExceeded);
         }
 
         amount_out
     }
 
+    /// Swap at most `max_amount_in` of `token_in` for an exact amount of `token_out`.
+    ///
+    /// # Arguments
+    /// * `token_in`    - Address of the token being sold.
+    /// * `token_out`   - Address of the token being bought.
+    /// * `amount_out`  - Exact amount of `token_out` desired. Must be > 0.
+    /// * `max_amount_in` - Maximum acceptable input (slippage guard).
+    /// * `deadline`    - Unix timestamp after which the transaction reverts.
+    ///
+    /// # Returns
+    /// The actual amount of `token_in` consumed.
     pub fn exact_output_single(
         env: Env,
         token_in: Address,
@@ -66,17 +127,28 @@ impl Router {
         deadline: u64,
     ) -> i128 {
         ensure_deadline(&env, deadline);
-        ensure_positive_amount(amount_out);
+        ensure_positive_amount(&env, amount_out);
 
         let amount_in = quote_exact_output_hop(&env, &token_in, &token_out, amount_out);
         if amount_in > max_amount_in {
-            panic!("excessive input");
+            panic_with_error!(&env, RouterError::ExcessiveInput);
         }
 
         publish_swap(&env, token_in, token_out, amount_in, amount_out);
         amount_in
     }
 
+    /// Swap an exact amount of the first token in `path` for at least `min_amount_out`
+    /// of the last token, routing through every consecutive pair in the path.
+    ///
+    /// # Arguments
+    /// * `path`          - Ordered list of token addresses (≥ 2 elements).
+    /// * `amount_in`     - Exact amount of `path[0]` to sell. Must be > 0.
+    /// * `min_amount_out`- Minimum acceptable amount of `path[last]`.
+    /// * `deadline`      - Unix timestamp after which the transaction reverts.
+    ///
+    /// # Returns
+    /// The actual amount of the final token received.
     pub fn exact_input(
         env: Env,
         path: Vec<Address>,
@@ -85,8 +157,8 @@ impl Router {
         deadline: u64,
     ) -> i128 {
         ensure_deadline(&env, deadline);
-        ensure_positive_amount(amount_in);
-        ensure_path(&path);
+        ensure_positive_amount(&env, amount_in);
+        ensure_path(&env, &path);
 
         let mut amount = amount_in;
         let mut index = 0;
@@ -99,12 +171,23 @@ impl Router {
         }
 
         if amount < min_amount_out {
-            panic!("slippage breach");
+            panic_with_error!(&env, RouterError::SlippageExceeded);
         }
 
         amount
     }
 
+    /// Swap at most `max_amount_in` of the first token in `path` for an exact amount
+    /// of the last token, routing through every consecutive pair in the path.
+    ///
+    /// # Arguments
+    /// * `path`         - Ordered list of token addresses (≥ 2 elements).
+    /// * `amount_out`   - Exact amount of `path[last]` desired. Must be > 0.
+    /// * `max_amount_in`- Maximum acceptable amount of `path[0]`.
+    /// * `deadline`     - Unix timestamp after which the transaction reverts.
+    ///
+    /// # Returns
+    /// The actual amount of the first token consumed.
     pub fn exact_output(
         env: Env,
         path: Vec<Address>,
@@ -113,8 +196,8 @@ impl Router {
         deadline: u64,
     ) -> i128 {
         ensure_deadline(&env, deadline);
-        ensure_positive_amount(amount_out);
-        ensure_path(&path);
+        ensure_positive_amount(&env, amount_out);
+        ensure_path(&env, &path);
 
         let mut amount = amount_out;
         let mut index = path.len() - 1;
@@ -129,32 +212,41 @@ impl Router {
         }
 
         if amount > max_amount_in {
-            panic!("excessive input");
+            panic_with_error!(&env, RouterError::ExcessiveInput);
         }
 
         amount
     }
 
+    /// Returns the router's balance of `token`. Always 0 — the router is stateless.
+    ///
+    /// # Arguments
+    /// * `_token` - Token address (unused; present for interface compatibility).
+    ///
+    /// # Returns
+    /// `0i128`.
     pub fn get_router_balance(_env: Env, _token: Address) -> i128 {
         0
     }
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
 fn ensure_deadline(env: &Env, deadline: u64) {
     if env.ledger().timestamp() > deadline {
-        panic!("expired deadline");
+        panic_with_error!(env, RouterError::DeadlineExpired);
     }
 }
 
-fn ensure_positive_amount(amount: i128) {
+fn ensure_positive_amount(env: &Env, amount: i128) {
     if amount <= 0 {
-        panic!("invalid amount");
+        panic_with_error!(env, RouterError::InvalidAmount);
     }
 }
 
-fn ensure_path(path: &Vec<Address>) {
+fn ensure_path(env: &Env, path: &Vec<Address>) {
     if path.len() < 2 {
-        panic!("invalid path");
+        panic_with_error!(env, RouterError::InvalidPath);
     }
 }
 
@@ -167,7 +259,7 @@ fn execute_exact_input_hop(
     let rate = read_pool_rate(env, &token_in, &token_out);
     let amount_out = amount_in
         .checked_mul(rate)
-        .unwrap_or_else(|| panic!("swap overflow"));
+        .unwrap_or_else(|| panic_with_error!(env, RouterError::Overflow));
 
     publish_swap(env, token_in, token_out, amount_in, amount_out);
     amount_out
@@ -187,7 +279,7 @@ fn read_pool_rate(env: &Env, token_in: &Address, token_out: &Address) -> i128 {
     env.storage()
         .instance()
         .get(&DataKey::Pool(token_in.clone(), token_out.clone()))
-        .unwrap_or_else(|| panic!("hop failed"))
+        .unwrap_or_else(|| panic_with_error!(env, RouterError::PoolNotFound))
 }
 
 fn div_ceil(value: i128, divisor: i128) -> i128 {

--- a/packages/sdk/src/swap.ts
+++ b/packages/sdk/src/swap.ts
@@ -1,20 +1,39 @@
+/** Identifies a pool by its two token addresses. */
+export interface PoolId {
+  token0: string;
+  token1: string;
+}
+
+/** Parameters for building an exact-input single-hop swap transaction. */
 export interface SwapTxParams {
+  /** On-chain pool contract address. */
   poolId: string;
+  /** Contract address of the token being sold. */
   tokenInId: string;
+  /** Contract address of the token being bought. */
   tokenOutId: string;
+  /** Raw amount of `tokenIn` to sell (as a string to avoid JS bigint loss). */
   amountIn: string;
-  minimumReceived: string; // slippage-adjusted minimum out
+  /** Slippage-adjusted minimum amount of `tokenOut` to receive. */
+  minimumReceived: string;
+  /** Stellar account address of the transaction submitter / recipient. */
   ownerAddress: string;
 }
 
+/** An unsigned Soroban transaction envelope ready for wallet signing. */
 export interface SwapUnsignedTx {
+  /** Base-64 encoded XDR of the transaction envelope. */
   xdr: string;
+  /** Discriminant so callers can narrow the union type. */
   type: "swap";
 }
 
 /**
  * Builds an unsigned swap transaction XDR.
  * Stub — replace with real Soroban router contract invocation via stellar-sdk.
+ *
+ * @param params - Swap parameters including pool, tokens, amounts, and signer.
+ * @returns An unsigned transaction envelope in XDR format.
  */
 export function buildSwapTx(params: SwapTxParams): SwapUnsignedTx {
   const payload = JSON.stringify({ op: "swap", ...params });


### PR DESCRIPTION
packages/contracts/router/src/lib.rs:
- replace all panic!("string") with typed RouterError via contracterror macro
- add RouterError enum: DeadlineExpired, InvalidAmount, InvalidPath, PoolNotFound, SlippageExceeded, ExcessiveInput, Overflow
- pass &env to all guard helpers so errors are emitted as contract errors
- add doc comments to all public contract methods and SwapEvent fields

packages/sdk/src/swap.ts:
- add strict JSDoc to SwapTxParams, SwapUnsignedTx, and buildSwapTx
- add PoolId interface for typed pool references
- inline comments replaced with proper field-level JSDoc

## Summary
<!-- What does this PR do? -->

## Related issue
- Closes #146

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist
- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed