### PR TITLE
[topup] [sdk] Improve TypeScript types in swap builder (2)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,8 +1,8 @@
 export { calculateSwapQuote, EMPTY_QUOTE, isEmptyQuote } from './quote';
-export type { SwapQuoteParams, SwapQuote } from './quote';
+export type { SwapQuoteParams, SwapQuote, LocalSwapQuoteParams, LocalSwapQuote, PoolStateWithTicks } from './quote';
 
-export { buildBurnTx, buildCollectTx, estimateRemoveAmounts } from './liquidity';
-export type { BurnTxParams, CollectTxParams, UnsignedTx } from './liquidity';
+export { buildBurnTx, buildCollectTx, estimateRemoveAmounts, estimateRemoveAmountsAsync } from './liquidity';
+export type { BurnTxParams, CollectTxParams, UnsignedTx, BurnUnsignedTx, CollectUnsignedTx, RemoveAmountsResult } from './liquidity';
 
 // #69 — Pool query helpers
 export { getPool, getPosition, getTick } from './queries';

--- a/packages/sdk/src/liquidity.ts
+++ b/packages/sdk/src/liquidity.ts
@@ -1,49 +1,76 @@
 export interface BurnTxParams {
-  positionId: string;
-  poolId: string;
-  liquidityBps: number; // 0–10000, basis points of total liquidity to remove
-  ownerAddress: string;
+  readonly positionId: string;
+  readonly poolId: string;
+  /** Basis points of total liquidity to remove (0–10000). */
+  readonly liquidityBps: number;
+  readonly ownerAddress: string;
 }
 
 export interface CollectTxParams {
-  positionId: string;
-  poolId: string;
-  ownerAddress: string;
+  readonly positionId: string;
+  readonly poolId: string;
+  readonly ownerAddress: string;
 }
 
-export interface UnsignedTx {
-  xdr: string; // base64 XDR envelope — stub value until Soroban sim is wired
-  type: "burn" | "collect";
+/** Unsigned burn (remove-liquidity) transaction envelope. */
+export interface BurnUnsignedTx {
+  /** Base-64 encoded XDR envelope — stub value until Soroban sim is wired. */
+  readonly xdr: string;
+  readonly type: 'burn';
+}
+
+/** Unsigned collect-fees transaction envelope. */
+export interface CollectUnsignedTx {
+  /** Base-64 encoded XDR envelope — stub value until Soroban sim is wired. */
+  readonly xdr: string;
+  readonly type: 'collect';
+}
+
+/** Discriminated union of all unsigned liquidity-management transaction types. */
+export type UnsignedTx = BurnUnsignedTx | CollectUnsignedTx;
+
+/** Token amounts returned when removing liquidity. */
+export interface RemoveAmountsResult {
+  readonly amount0: string;
+  readonly amount1: string;
 }
 
 /**
  * Builds an unsigned burn (remove liquidity) transaction XDR.
  * Stub — replace with real Soroban contract invocation via stellar-sdk.
  */
-export function buildBurnTx(params: BurnTxParams): UnsignedTx {
-  const payload = JSON.stringify({ op: "burn", ...params });
-  const xdr = Buffer.from(payload).toString("base64");
-  return { xdr, type: "burn" };
+export function buildBurnTx(params: BurnTxParams): BurnUnsignedTx {
+  const payload = JSON.stringify({ op: 'burn', ...params });
+  const xdr = Buffer.from(payload).toString('base64');
+  return { xdr, type: 'burn' };
 }
 
 /**
  * Builds an unsigned collect-fees transaction XDR.
  * Stub — replace with real Soroban contract invocation via stellar-sdk.
  */
-export function buildCollectTx(params: CollectTxParams): UnsignedTx {
-  const payload = JSON.stringify({ op: "collect", ...params });
-  const xdr = Buffer.from(payload).toString("base64");
-  return { xdr, type: "collect" };
+export function buildCollectTx(params: CollectTxParams): CollectUnsignedTx {
+  const payload = JSON.stringify({ op: 'collect', ...params });
+  const xdr = Buffer.from(payload).toString('base64');
+  return { xdr, type: 'collect' };
 }
 
-/** Estimate token amounts returned for a given liquidity removal percentage. */
+/**
+ * Estimates token amounts returned for a given liquidity removal percentage.
+ *
+ * @param liquidity - Current position liquidity as a decimal string.
+ * @param pct - Percentage of liquidity to remove (0–100).
+ * @param currentPrice - Current pool price (token1/token0).
+ * @param lowerTick - Lower tick bound of the position.
+ * @param upperTick - Upper tick bound of the position.
+ */
 export function estimateRemoveAmounts(
   liquidity: string,
-  pct: number, // 0–100
+  pct: number,
   currentPrice: number,
   lowerTick: number,
-  upperTick: number
-): { amount0: string; amount1: string } {
+  upperTick: number,
+): RemoveAmountsResult {
   const liq = parseFloat(liquidity);
   const fraction = pct / 100;
 
@@ -81,8 +108,8 @@ export async function estimateRemoveAmountsAsync(
   pct: number,
   currentPrice: number,
   lowerTick: number,
-  upperTick: number
-): Promise<{ amount0: string; amount1: string }> {
+  upperTick: number,
+): Promise<RemoveAmountsResult> {
   return new Promise((resolve) => {
     // Defer to next tick so callers can render loading UI
     Promise.resolve().then(() => {

--- a/packages/sdk/src/queries.ts
+++ b/packages/sdk/src/queries.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, Contract, xdr, scValToNative } from '@stellar/stellar-sdk';
+import { SorobanRpc, Contract, xdr, scValToNative, Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk';
 import { PoolState, PositionState, TickState, SwyftRpcError } from './types';
 
 async function callContract(
@@ -12,12 +12,12 @@ async function callContract(
   const op = contract.call(method, ...args);
 
   try {
+    // stellar-sdk's simulateTransaction requires a built Transaction or FeeBumpTransaction.
+    // The Operation returned by contract.call() is cast here because the stub simulation
+    // path only needs the operation XDR; replace with a fully-built transaction once
+    // the Soroban signing flow is wired up.
     const result = await server.simulateTransaction(
-      // We only need the result value; build a minimal transaction envelope
-      // by wrapping the operation in a simulation request directly.
-      // stellar-sdk's simulateTransaction accepts an Operation or a built tx;
-      // here we pass the raw operation xdr for simulation.
-      op as unknown as Parameters<typeof server.simulateTransaction>[0],
+      op as unknown as Transaction | FeeBumpTransaction,
     );
 
     if (SorobanRpc.Api.isSimulationError(result)) {
@@ -31,11 +31,20 @@ async function callContract(
     return sim.result.retval;
   } catch (err) {
     if (err instanceof SwyftRpcError) throw err;
+    const message = err instanceof Error ? err.message : String(err);
     throw new SwyftRpcError(
-      `RPC call failed for ${method} on ${contractAddress}: ${(err as Error).message}`,
+      `RPC call failed for ${method} on ${contractAddress}: ${message}`,
       err,
     );
   }
+}
+
+/** Asserts that a raw scValToNative result is a plain object, throwing on unexpected shapes. */
+function assertRawObject(raw: unknown, context: string): Record<string, unknown> {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new SwyftRpcError(`Unexpected response shape from ${context}`);
+  }
+  return raw as Record<string, unknown>;
 }
 
 export async function getPool({
@@ -46,11 +55,7 @@ export async function getPool({
   poolAddress: string;
 }): Promise<PoolState> {
   const retval = await callContract(rpcUrl, poolAddress, 'get_pool_state');
-  const raw = scValToNative(retval) as Record<string, unknown>;
-
-  if (!raw || typeof raw !== 'object') {
-    throw new SwyftRpcError(`Unexpected pool state shape from ${poolAddress}`);
-  }
+  const raw = assertRawObject(scValToNative(retval), poolAddress);
 
   return {
     poolAddress,
@@ -72,11 +77,7 @@ export async function getPosition({
 }): Promise<PositionState> {
   // positionNftId is the NFT contract address that holds the position
   const retval = await callContract(rpcUrl, positionNftId, 'get_position');
-  const raw = scValToNative(retval) as Record<string, unknown>;
-
-  if (!raw || typeof raw !== 'object') {
-    throw new SwyftRpcError(`Unexpected position state shape from ${positionNftId}`);
-  }
+  const raw = assertRawObject(scValToNative(retval), positionNftId);
 
   return {
     positionNftId,
@@ -99,11 +100,7 @@ export async function getTick({
 }): Promise<TickState> {
   const tickArg = xdr.ScVal.scvI32(tick);
   const retval = await callContract(rpcUrl, poolAddress, 'get_tick', [tickArg]);
-  const raw = scValToNative(retval) as Record<string, unknown>;
-
-  if (!raw || typeof raw !== 'object') {
-    throw new SwyftRpcError(`Unexpected tick state shape for tick ${tick} on ${poolAddress}`);
-  }
+  const raw = assertRawObject(scValToNative(retval), `tick ${tick} on ${poolAddress}`);
 
   return {
     tick,

--- a/packages/sdk/src/quote.ts
+++ b/packages/sdk/src/quote.ts
@@ -1,39 +1,66 @@
-import { PoolState, TickState } from "./types";
+import { PoolState, TickState } from './types';
 
 const Q96 = 2n ** 96n;
 const MAX_TICK = 887272;
 const MIN_TICK = -887272;
 
 export interface SwapQuoteParams {
-  poolId: string;
-  tokenInId: string;
-  tokenOutId: string;
-  amountIn: string;
-  slippageBps: number;
+  readonly poolId: string;
+  readonly tokenInId: string;
+  readonly tokenOutId: string;
+  readonly amountIn: string;
+  readonly slippageBps: number;
 }
 
 export interface SwapQuote {
-  amountOut: string;
-  priceImpact: number;
-  lpFee: string;
-  protocolFee: string;
-  minimumReceived: string;
-  executionPrice: string;
+  readonly amountOut: string;
+  readonly priceImpact: number;
+  readonly lpFee: string;
+  readonly protocolFee: string;
+  readonly minimumReceived: string;
+  readonly executionPrice: string;
+}
+
+/** Pool state extended with optional tick ladder for local simulation. */
+export type PoolStateWithTicks = PoolState & { readonly ticks?: readonly TickState[] };
+
+export interface LocalSwapQuoteParams {
+  readonly poolState: PoolStateWithTicks;
+  readonly tokenIn: string;
+  readonly amountIn: string | bigint;
+  /** Slippage tolerance in basis points (0–10000). */
+  readonly slippage: number;
+}
+
+export interface LocalSwapQuote {
+  readonly amountOut: string;
+  readonly priceImpact: number;
+  readonly fee: string;
+  readonly minimumReceived: string;
+  readonly sqrtPriceLimitX96: string;
+}
+
+/** Intermediate result of a single tick-crossing swap step. */
+interface SwapStepResult {
+  readonly amountIn: bigint;
+  readonly amountOut: bigint;
+  readonly nextSqrtPrice: bigint;
+  readonly reachedTarget: boolean;
 }
 
 /** A zero-value quote returned when inputs are missing or invalid. */
 export const EMPTY_QUOTE: SwapQuote = {
-  amountOut: "0",
+  amountOut: '0',
   priceImpact: 0,
-  lpFee: "0",
-  protocolFee: "0",
-  minimumReceived: "0",
-  executionPrice: "0",
+  lpFee: '0',
+  protocolFee: '0',
+  minimumReceived: '0',
+  executionPrice: '0',
 };
 
 /** Returns true when a quote carries no meaningful output (e.g. empty input). */
 export function isEmptyQuote(quote: SwapQuote): boolean {
-  return quote.amountOut === "0" && quote.executionPrice === "0";
+  return quote.amountOut === '0' && quote.executionPrice === '0';
 }
 
 export function calculateSwapQuote(params: SwapQuoteParams): SwapQuote {
@@ -50,37 +77,22 @@ export function calculateSwapQuote(params: SwapQuoteParams): SwapQuote {
   const amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
   const spotPrice = reserveOut / reserveIn;
   const executionPrice = amountOut / amountIn;
-  const priceImpact = Math.max(0, ((spotPrice - executionPrice) / spotPrice) * 100);
+  const priceImpactPct = Math.max(0, ((spotPrice - executionPrice) / spotPrice) * 100);
   const minimumReceived = amountOut * (1 - params.slippageBps / 10_000);
   return {
     amountOut: amountOut.toFixed(7),
-    priceImpact: parseFloat(priceImpact.toFixed(4)),
+    priceImpact: parseFloat(priceImpactPct.toFixed(4)),
     lpFee: lpFeeAmt.toFixed(7),
-    protocolFee: "0",
+    protocolFee: '0',
     minimumReceived: minimumReceived.toFixed(7),
     executionPrice: executionPrice.toFixed(7),
   };
 }
 
-export interface LocalSwapQuoteParams {
-  poolState: PoolState & { ticks?: TickState[] };
-  tokenIn: string;
-  amountIn: string | bigint;
-  slippage: number;
-}
-
-export interface LocalSwapQuote {
-  amountOut: string;
-  priceImpact: number;
-  fee: string;
-  minimumReceived: string;
-  sqrtPriceLimitX96: string;
-}
-
 export function getSwapQuote(params: LocalSwapQuoteParams): LocalSwapQuote {
   const amountIn = toBigIntAmount(params.amountIn);
   if (amountIn <= 0n) {
-    throw new Error("amountIn must be greater than zero");
+    throw new Error('amountIn must be greater than zero');
   }
 
   const zeroForOne = direction(params.poolState, params.tokenIn);
@@ -89,13 +101,13 @@ export function getSwapQuote(params: LocalSwapQuoteParams): LocalSwapQuote {
   let currentTick = params.poolState.currentTick;
 
   if (liquidity <= 0n) {
-    throw new Error("zero liquidity in current range");
+    throw new Error('zero liquidity in current range');
   }
 
   const fee = mulDivRoundingUp(amountIn, feeUnits(params.poolState.feeTier), 1_000_000n);
   let remaining = amountIn - fee;
   if (remaining <= 0n) {
-    throw new Error("amountIn is fully consumed by fees");
+    throw new Error('amountIn is fully consumed by fees');
   }
 
   let amountOut = 0n;
@@ -103,14 +115,14 @@ export function getSwapQuote(params: LocalSwapQuoteParams): LocalSwapQuote {
 
   while (remaining > 0n) {
     if (liquidity <= 0n) {
-      throw new Error("zero liquidity in range");
+      throw new Error('zero liquidity in range');
     }
 
     const nextTick = ticks.shift();
     const targetTick = nextTick?.tick ?? (zeroForOne ? MIN_TICK : MAX_TICK);
     const targetSqrtPrice = sqrtRatioAtTick(targetTick);
 
-    const step = zeroForOne
+    const step: SwapStepResult = zeroForOne
       ? swapToken0ForToken1Step(remaining, liquidity, sqrtPrice, targetSqrtPrice)
       : swapToken1ForToken0Step(remaining, liquidity, sqrtPrice, targetSqrtPrice);
 
@@ -123,7 +135,7 @@ export function getSwapQuote(params: LocalSwapQuoteParams): LocalSwapQuote {
     }
 
     if (!nextTick) {
-      throw new Error("amount exceeds available liquidity");
+      throw new Error('amount exceeds available liquidity');
     }
 
     liquidity = zeroForOne
@@ -136,7 +148,7 @@ export function getSwapQuote(params: LocalSwapQuoteParams): LocalSwapQuote {
 
   return {
     amountOut: amountOut.toString(),
-    priceImpact: priceImpact(params.poolState.sqrtPrice, sqrtPrice),
+    priceImpact: calcPriceImpact(params.poolState.sqrtPrice, sqrtPrice),
     fee: fee.toString(),
     minimumReceived: minimumReceived.toString(),
     sqrtPriceLimitX96: sqrtPrice.toString(),
@@ -146,11 +158,11 @@ export function getSwapQuote(params: LocalSwapQuoteParams): LocalSwapQuote {
 function direction(pool: PoolState, tokenIn: string): boolean {
   if (tokenIn === pool.token0) return true;
   if (tokenIn === pool.token1) return false;
-  throw new Error("invalid token direction");
+  throw new Error('invalid token direction');
 }
 
 function sortedTicks(
-  ticks: TickState[],
+  ticks: readonly TickState[],
   zeroForOne: boolean,
   currentTick: number,
 ): TickState[] {
@@ -164,7 +176,7 @@ function swapToken0ForToken1Step(
   liquidity: bigint,
   sqrtPrice: bigint,
   targetSqrtPrice: bigint,
-) {
+): SwapStepResult {
   const amountToTarget = getAmount0Delta(targetSqrtPrice, sqrtPrice, liquidity, true);
 
   if (amountRemaining >= amountToTarget) {
@@ -190,7 +202,7 @@ function swapToken1ForToken0Step(
   liquidity: bigint,
   sqrtPrice: bigint,
   targetSqrtPrice: bigint,
-) {
+): SwapStepResult {
   const amountToTarget = getAmount1Delta(sqrtPrice, targetSqrtPrice, liquidity, true);
 
   if (amountRemaining >= amountToTarget) {
@@ -249,7 +261,7 @@ function sqrtRatioAtTick(tick: number): bigint {
   return BigInt(Math.floor(ratio * Number(Q96)));
 }
 
-function priceImpact(startSqrt: string, endSqrt: bigint): number {
+function calcPriceImpact(startSqrt: string, endSqrt: bigint): number {
   const start = Number(BigInt(startSqrt));
   const end = Number(endSqrt);
   if (!Number.isFinite(start) || !Number.isFinite(end) || start === 0) return 0;
@@ -260,20 +272,20 @@ function priceImpact(startSqrt: string, endSqrt: bigint): number {
 
 function applySlippage(amountOut: bigint, slippage: number): bigint {
   const bps = BigInt(Math.max(0, Math.floor(slippage)));
-  if (bps > 10_000n) throw new Error("slippage cannot exceed 10000 bps");
+  if (bps > 10_000n) throw new Error('slippage cannot exceed 10000 bps');
   return (amountOut * (10_000n - bps)) / 10_000n;
 }
 
 function feeUnits(feeTier: number): bigint {
   if (!Number.isInteger(feeTier) || feeTier < 0 || feeTier >= 1_000_000) {
-    throw new Error("invalid fee tier");
+    throw new Error('invalid fee tier');
   }
   return BigInt(feeTier);
 }
 
 function toBigIntAmount(value: string | bigint): bigint {
-  if (typeof value === "bigint") return value;
-  if (!/^\d+$/.test(value)) throw new Error("amountIn must be an integer string");
+  if (typeof value === 'bigint') return value;
+  if (!/^\d+$/.test(value)) throw new Error('amountIn must be an integer string');
   return BigInt(value);
 }
 

--- a/packages/sdk/src/swap.ts
+++ b/packages/sdk/src/swap.ts
@@ -1,31 +1,31 @@
 /** Identifies a pool by its two token addresses. */
 export interface PoolId {
-  token0: string;
-  token1: string;
+  readonly token0: string;
+  readonly token1: string;
 }
 
 /** Parameters for building an exact-input single-hop swap transaction. */
 export interface SwapTxParams {
   /** On-chain pool contract address. */
-  poolId: string;
+  readonly poolId: string;
   /** Contract address of the token being sold. */
-  tokenInId: string;
+  readonly tokenInId: string;
   /** Contract address of the token being bought. */
-  tokenOutId: string;
+  readonly tokenOutId: string;
   /** Raw amount of `tokenIn` to sell (as a string to avoid JS bigint loss). */
-  amountIn: string;
+  readonly amountIn: string;
   /** Slippage-adjusted minimum amount of `tokenOut` to receive. */
-  minimumReceived: string;
+  readonly minimumReceived: string;
   /** Stellar account address of the transaction submitter / recipient. */
-  ownerAddress: string;
+  readonly ownerAddress: string;
 }
 
 /** An unsigned Soroban transaction envelope ready for wallet signing. */
 export interface SwapUnsignedTx {
   /** Base-64 encoded XDR of the transaction envelope. */
-  xdr: string;
+  readonly xdr: string;
   /** Discriminant so callers can narrow the union type. */
-  type: "swap";
+  readonly type: 'swap';
 }
 
 /**
@@ -36,7 +36,7 @@ export interface SwapUnsignedTx {
  * @returns An unsigned transaction envelope in XDR format.
  */
 export function buildSwapTx(params: SwapTxParams): SwapUnsignedTx {
-  const payload = JSON.stringify({ op: "swap", ...params });
+  const payload = JSON.stringify({ op: 'swap', ...params });
   const xdr = btoa(payload);
-  return { xdr, type: "swap" };
+  return { xdr, type: 'swap' };
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,27 +1,27 @@
 export interface PoolState {
-  poolAddress: string;
-  sqrtPrice: string;
-  currentTick: number;
-  liquidity: string;
-  feeTier: number;
-  token0: string;
-  token1: string;
+  readonly poolAddress: string;
+  readonly sqrtPrice: string;
+  readonly currentTick: number;
+  readonly liquidity: string;
+  readonly feeTier: number;
+  readonly token0: string;
+  readonly token1: string;
 }
 
 export interface PositionState {
-  positionNftId: string;
-  owner: string;
-  pool: string;
-  lowerTick: number;
-  upperTick: number;
-  liquidity: string;
+  readonly positionNftId: string;
+  readonly owner: string;
+  readonly pool: string;
+  readonly lowerTick: number;
+  readonly upperTick: number;
+  readonly liquidity: string;
 }
 
 export interface TickState {
-  tick: number;
-  liquidityNet: string;
-  liquidityGross: string;
-  feeGrowthOutside: string;
+  readonly tick: number;
+  readonly liquidityNet: string;
+  readonly liquidityGross: string;
+  readonly feeGrowthOutside: string;
 }
 
 export class SwyftRpcError extends Error {


### PR DESCRIPTION
Closes #199  [topup] [sdk] Improve TypeScript types in swap builder (2)
- Add readonly to all interface fields in types.ts, swap.ts, quote.ts, liquidity.ts
- Extract SwapStepResult interface with explicit return types for step functions
- Extract PoolStateWithTicks named type replacing inline intersection
- Extract RemoveAmountsResult named interface for estimateRemoveAmounts
- Split UnsignedTx into BurnUnsignedTx | CollectUnsignedTx discriminated union
- Safe error narrowing in queries.ts (instanceof check instead of cast)
- Tighten simulateTransaction cast to Transaction | FeeBumpTransaction
- Add assertRawObject helper to deduplicate RPC response validation
- Export new types from index.ts

## Summary
<!-- What does this PR do? -->

## Related issue
- Closes #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist
- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed