### PR TITLE
feat: resolve issues #189 #190 #191 #192

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage/
 *.snap
 __snapshots__/
 .nyc_output/
+*.test-results/
+test-results/
+playwright-report/
 
 # logs
 *.log
@@ -41,3 +44,12 @@ Thumbs.db
 # misc
 .gitkeep
 *.tsbuildinfo
+
+# Rust / Soroban
+Cargo.lock
+*.wasm
+target/
+
+# package manager lockfiles (root — per-package locks are kept)
+package-lock.json
+yarn.lock

--- a/apps/api/src/pools/pools.controller.ts
+++ b/apps/api/src/pools/pools.controller.ts
@@ -33,6 +33,12 @@ export class PoolsController {
     status: 200,
     description: 'Returns a paginated list of pools. Items array is empty when no pools match.',
   })
+  /**
+   * Returns a paginated list of active pools.
+   *
+   * @param query - Pagination and filter options (page, limit, feeTier, token).
+   * @returns A paginated response containing pool summaries and total count.
+   */
   async getPools(@Query() query: GetPoolsQueryDto): Promise<PoolsListResponse> {
     const result = await this.poolsService.getPools(query);
 
@@ -45,6 +51,14 @@ export class PoolsController {
   @ApiParam({ name: 'id', description: 'Pool ID (cuid or contract address)' })
   @ApiResponse({ status: 200, type: PoolDetailDto, description: 'Pool details retrieved successfully' })
   @ApiResponse({ status: 404, description: 'Pool not found' })
+  /**
+   * Returns full details for a single pool, including token pair, fee tier, and current price.
+   * Results are cached for 15 seconds.
+   *
+   * @param id - Pool ID (cuid) or Soroban contract address.
+   * @returns Pool detail object.
+   * @throws NotFoundException when no pool matches the given ID.
+   */
   async getPoolById(@Param('id') id: string): Promise<PoolDetailDto> {
     const cacheKey = `pool:${id}`;
 
@@ -90,6 +104,16 @@ export class PoolsController {
   })
   @ApiResponse({ status: 400, description: 'Invalid tick range' })
   @ApiResponse({ status: 404, description: 'Pool not found' })
+  /**
+   * Returns initialized tick data for a pool, optionally filtered to a tick range.
+   * Ticks are returned in ascending order by tick index.
+   *
+   * @param id - Pool ID (cuid) or Soroban contract address.
+   * @param query - Optional `lowerTick` and `upperTick` bounds (inclusive). If omitted, all ticks are returned.
+   * @returns Array of tick data objects. Empty array when the pool has no ticks in the requested range.
+   * @throws NotFoundException when no pool matches the given ID.
+   * @throws BadRequestException when `lowerTick` is greater than `upperTick`.
+   */
   async getPoolTicks(
     @Param('id') id: string,
     @Query() query: GetTicksQueryDto,

--- a/apps/web/components/SwapWidget.tsx
+++ b/apps/web/components/SwapWidget.tsx
@@ -240,6 +240,7 @@ export function SwapWidget({
     !amountIn ||
     parseFloat(amountIn) <= 0 ||
     insufficient ||
+    quoteLoading ||
     !quote;
 
   function selectIn(token: Token) {
@@ -526,9 +527,14 @@ export function SwapWidget({
             onClick={() => setShowModal(true)}
             disabled={swapDisabled}
             aria-disabled={swapDisabled}
-            className="mt-1 w-full min-h-[44px] rounded-xl bg-indigo-600 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-1 w-full min-h-[44px] rounded-xl bg-indigo-600 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 flex items-center justify-center gap-2"
           >
-            {!wallet.address
+            {quoteLoading ? (
+              <>
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" aria-hidden="true" />
+                Fetching quote…
+              </>
+            ) : !wallet.address
               ? "Connect wallet to swap"
               : !pair.tokenIn || !pair.tokenOut
               ? "Select tokens"

--- a/apps/web/components/TransactionHistory.tsx
+++ b/apps/web/components/TransactionHistory.tsx
@@ -24,7 +24,7 @@ export function TransactionHistory({ walletAddress }: TransactionHistoryProps) {
   const filteredLpActivity = filterByDate(lpData?.items || [], startDate, endDate);
 
   const totalPages = Math.ceil(
-    (activeTab === "swaps" ? swapsData?.total : lpData?.total || 0) / 20
+    (activeTab === "swaps" ? (swapsData?.total ?? 0) : (lpData?.total ?? 0)) / 20
   );
 
   function filterByDate<T extends { timestamp: number }>(items: T[], start: string, end: string): T[] {
@@ -270,7 +270,7 @@ function LpTable({ activities, loading, error, getExplorerUrl, formatDate, trunc
     );
   }
 
-  const getTypeColor = (type: string) => {
+  const getTypeColor = (type: LpActivityType): string => {
     switch (type) {
       case "mint":
         return "text-emerald-600 dark:text-emerald-400";
@@ -278,12 +278,10 @@ function LpTable({ activities, loading, error, getExplorerUrl, formatDate, trunc
         return "text-red-600 dark:text-red-400";
       case "fee_collection":
         return "text-amber-600 dark:text-amber-400";
-      default:
-        return "text-zinc-600 dark:text-zinc-400";
     }
   };
 
-  const getTypeLabel = (type: string) => {
+  const getTypeLabel = (type: LpActivityType): string => {
     switch (type) {
       case "mint":
         return "Add";
@@ -291,8 +289,6 @@ function LpTable({ activities, loading, error, getExplorerUrl, formatDate, trunc
         return "Remove";
       case "fee_collection":
         return "Fees";
-      default:
-        return type;
     }
   };
 

--- a/apps/web/hooks/usePositions.ts
+++ b/apps/web/hooks/usePositions.ts
@@ -35,24 +35,34 @@ export function usePosition(id: string | null, authToken: string | null) {
 export function usePositions(authToken: string | null) {
   const [positions, setPositions] = useState<PositionSnapshot[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!authToken) { setPositions([]); return; }
     let cancelled = false;
     setLoading(true);
+    setError(null);
 
     fetch(`${API_BASE}/positions?status=active`, {
       headers: { Authorization: `Bearer ${authToken}` },
     })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load positions");
+        return r.json();
+      })
       .then((data: { items?: PositionSnapshot[] }) => {
         if (!cancelled) setPositions(data.items ?? []);
       })
-      .catch(() => { if (!cancelled) setPositions([]); })
+      .catch((e: Error) => {
+        if (!cancelled) {
+          setPositions([]);
+          setError(e.message);
+        }
+      })
       .finally(() => { if (!cancelled) setLoading(false); });
 
     return () => { cancelled = true; };
   }, [authToken]);
 
-  return { positions, loading };
+  return { positions, loading, error };
 }

--- a/apps/web/hooks/useSwaps.ts
+++ b/apps/web/hooks/useSwaps.ts
@@ -19,7 +19,6 @@ export interface SwapSnapshot {
 export interface SwapsListResponse {
   items: SwapSnapshot[];
   total: number;
-  isLoading: boolean;
 }
 
 export function useSwaps(walletAddress: string | null, page: number = 1, limit: number = 20) {

--- a/packages/sdk/src/queries.ts
+++ b/packages/sdk/src/queries.ts
@@ -69,14 +69,20 @@ export async function getPosition({
 }: {
   rpcUrl: string;
   positionNftId: string;
-}): Promise<PositionState> {
-  // positionNftId is the NFT contract address that holds the position
-  const retval = await callContract(rpcUrl, positionNftId, 'get_position');
-  const raw = scValToNative(retval) as Record<string, unknown>;
-
-  if (!raw || typeof raw !== 'object') {
-    throw new SwyftRpcError(`Unexpected position state shape from ${positionNftId}`);
+}): Promise<PositionState | null> {
+  let retval: xdr.ScVal;
+  try {
+    retval = await callContract(rpcUrl, positionNftId, 'get_position');
+  } catch (err) {
+    if (err instanceof SwyftRpcError) return null;
+    throw err;
   }
+
+  // Contract may return void/null when the position does not exist
+  if (retval.switch().name === 'scvVoid') return null;
+
+  const raw = scValToNative(retval) as Record<string, unknown>;
+  if (!raw || typeof raw !== 'object') return null;
 
   return {
     positionNftId,


### PR DESCRIPTION
#189 - Strict TS types in TransactionHistory: use LpActivityType in getTypeColor/getTypeLabel (exhaustive switch, no default), fix totalPages nullish coalescing, remove isLoading from SwapsListResponse data interface.
#190 - Add JSDoc to all three exported endpoints in PoolsController: getPools, getPoolById, getPoolTicks — params and return types documented.
#191 - Handle empty data in SDK position queries: getPosition now returns null instead of throwing when contract returns void or RPC fails; usePositions hook exposes error state so UI can render a helpful message.
#192 - Add loading state to router contract frontend: swap button shows spinner and 'Fetching quote…' while quoteLoading is true; button is disabled during loading to prevent premature submission.
chore: update .gitignore — add test snapshots, playwright artifacts, *.wasm, Rust target/, and lockfile patterns.
Closes #189 
Closes #190 
Closes #191 
Closes #192 