### PR TITLE
feat: resolve issues #202, #203, #204, #206

### DIFF
--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -90,15 +90,23 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
       }).catch(() => null);
 
       if (counts) {
-        this.logger.log(
-          `queue=${worker.name} waiting=${counts.waiting} active=${counts.active}`,
-        );
+        if (counts.waiting === 0 && counts.active === 0) {
+          this.logger.debug(`queue=${worker.name} is empty — no events to process`);
+        } else {
+          this.logger.log(
+            `queue=${worker.name} waiting=${counts.waiting} active=${counts.active}`,
+          );
+        }
       }
     }
   }
 
   private async handlePoolCreated(job: Job<PoolCreatedJobData>) {
     const d = job.data;
+    if (!d?.eventId || !d?.poolId) {
+      this.logger.warn(`[indexer] handlePoolCreated: empty or incomplete data — jobId=${job.id}, skipping`);
+      return;
+    }
     await this.prisma.poolCreated.upsert({
       where: { eventId: d.eventId },
       update: {},
@@ -115,6 +123,10 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   private async handleSwapProcessed(job: Job<SwapProcessedJobData>) {
     const d = job.data;
+    if (!d?.eventId || !d?.poolId) {
+      this.logger.warn(`[indexer] handleSwapProcessed: empty or incomplete data — jobId=${job.id}, skipping`);
+      return;
+    }
     await this.prisma.swapProcessed.upsert({
       where: { eventId: d.eventId },
       update: {},
@@ -134,6 +146,10 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   private async handlePositionMinted(job: Job<PositionMintedJobData>) {
     const d = job.data;
+    if (!d?.eventId || !d?.poolId) {
+      this.logger.warn(`[indexer] handlePositionMinted: empty or incomplete data — jobId=${job.id}, skipping`);
+      return;
+    }
     await this.prisma.positionMinted.upsert({
       where: { eventId: d.eventId },
       update: {},
@@ -152,6 +168,10 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   private async handlePositionBurned(job: Job<PositionBurnedJobData>) {
     const d = job.data;
+    if (!d?.eventId || !d?.poolId) {
+      this.logger.warn(`[indexer] handlePositionBurned: empty or incomplete data — jobId=${job.id}, skipping`);
+      return;
+    }
     await this.prisma.positionBurned.upsert({
       where: { eventId: d.eventId },
       update: {},
@@ -170,6 +190,10 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   private async handleFeesCollected(job: Job<FeesCollectedJobData>) {
     const d = job.data;
+    if (!d?.eventId || !d?.poolId) {
+      this.logger.warn(`[indexer] handleFeesCollected: empty or incomplete data — jobId=${job.id}, skipping`);
+      return;
+    }
     await this.prisma.feesCollected.upsert({
       where: { eventId: d.eventId },
       update: {},

--- a/apps/web/hooks/useWebhooks.ts
+++ b/apps/web/hooks/useWebhooks.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { API_BASE } from "@/lib/constants";
+
+export interface WebhookItem {
+  id: string;
+  url: string;
+  eventTypes: string[];
+  disabled: boolean;
+  createdAt: string;
+}
+
+export function useWebhooks(authToken: string | null) {
+  const [items, setItems] = useState<WebhookItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchWebhooks = useCallback(() => {
+    if (!authToken) { setItems([]); return; }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch(`${API_BASE}/webhooks`, {
+      headers: { Authorization: `Bearer ${authToken}` },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load webhooks");
+        return r.json() as Promise<{ loading: boolean; items: WebhookItem[] }>;
+      })
+      .then((data) => { if (!cancelled) setItems(data.items); })
+      .catch((e: Error) => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [authToken]);
+
+  useEffect(() => {
+    const cancel = fetchWebhooks();
+    return cancel;
+  }, [fetchWebhooks]);
+
+  const createWebhook = useCallback(
+    async (body: { url: string; eventTypes: string[]; secret?: string; largeSwapUsd?: number }) => {
+      if (!authToken) return;
+      setLoading(true);
+      try {
+        const r = await fetch(`${API_BASE}/webhooks`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${authToken}`, "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!r.ok) throw new Error("Failed to create webhook");
+        fetchWebhooks();
+      } finally {
+        setLoading(false);
+      }
+    },
+    [authToken, fetchWebhooks],
+  );
+
+  const removeWebhook = useCallback(
+    async (id: string) => {
+      if (!authToken) return;
+      setLoading(true);
+      try {
+        await fetch(`${API_BASE}/webhooks/${id}`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${authToken}` },
+        });
+        fetchWebhooks();
+      } finally {
+        setLoading(false);
+      }
+    },
+    [authToken, fetchWebhooks],
+  );
+
+  return { items, loading, error, createWebhook, removeWebhook };
+}

--- a/packages/contract/contracts/math-lib/math-lib.types.ts
+++ b/packages/contract/contracts/math-lib/math-lib.types.ts
@@ -1,0 +1,99 @@
+/**
+ * Strict TypeScript types for the math-lib Soroban contract.
+ *
+ * These types mirror the Rust structs and enums in math-lib/src/lib.rs and
+ * are used by the TypeScript integration layer (scripts, SDK, tests).
+ *
+ * Closes #204 — Improve TypeScript types in math-lib.
+ */
+
+// ── Branded primitives ────────────────────────────────────────────────────────
+
+/** Q64.96 fixed-point sqrt price, represented as a bigint. */
+export type SqrtPriceX96 = bigint & { readonly __brand: "SqrtPriceX96" };
+
+/** Tick index, clamped to [MIN_TICK, MAX_TICK]. */
+export type Tick = number & { readonly __brand: "Tick" };
+
+/** Liquidity amount (non-negative integer). */
+export type Liquidity = bigint & { readonly __brand: "Liquidity" };
+
+/** Token amount (non-negative integer). */
+export type TokenAmount = bigint & { readonly __brand: "TokenAmount" };
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const Q96: SqrtPriceX96 = (1n << 96n) as SqrtPriceX96;
+export const MIN_TICK: Tick = -887272 as Tick;
+export const MAX_TICK: Tick = 887272 as Tick;
+
+// ── Error codes (mirrors MathError in lib.rs) ─────────────────────────────────
+
+export const MathErrorCode = {
+  InvalidTick: 1,
+  PriceOutOfBounds: 2,
+  Overflow: 3,
+  Underflow: 4,
+  DivisionByZero: 5,
+} as const;
+
+export type MathErrorCode = (typeof MathErrorCode)[keyof typeof MathErrorCode];
+
+export class MathError extends Error {
+  constructor(
+    public readonly code: MathErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "MathError";
+  }
+}
+
+// ── Parameter / result shapes ─────────────────────────────────────────────────
+
+export interface AmountDeltaParams {
+  liquidity: Liquidity;
+  sqrtPriceLowerX96: SqrtPriceX96;
+  sqrtPriceUpperX96: SqrtPriceX96;
+  sqrtPriceCurrentX96: SqrtPriceX96;
+}
+
+export interface AmountDeltaResult {
+  amount0: TokenAmount;
+  amount1: TokenAmount;
+}
+
+export interface NextSqrtPriceParams {
+  sqrtPriceX96: SqrtPriceX96;
+  liquidity: Liquidity;
+  amountIn: TokenAmount;
+  zeroForOne: boolean;
+}
+
+// ── Constructor helpers ───────────────────────────────────────────────────────
+
+/** Cast a raw bigint to SqrtPriceX96 (validates > 0). */
+export function toSqrtPriceX96(value: bigint): SqrtPriceX96 {
+  if (value <= 0n) throw new MathError(MathErrorCode.PriceOutOfBounds, "sqrtPriceX96 must be positive");
+  return value as SqrtPriceX96;
+}
+
+/** Cast a raw number to Tick (validates bounds). */
+export function toTick(value: number): Tick {
+  if (!Number.isInteger(value) || value < MIN_TICK || value > MAX_TICK) {
+    throw new MathError(MathErrorCode.InvalidTick, `tick ${value} out of [${MIN_TICK}, ${MAX_TICK}]`);
+  }
+  return value as Tick;
+}
+
+/** Cast a raw bigint to Liquidity (validates >= 0). */
+export function toLiquidity(value: bigint): Liquidity {
+  if (value < 0n) throw new MathError(MathErrorCode.Underflow, "liquidity must be non-negative");
+  return value as Liquidity;
+}
+
+/** Cast a raw bigint to TokenAmount (validates >= 0). */
+export function toTokenAmount(value: bigint): TokenAmount {
+  if (value < 0n) throw new MathError(MathErrorCode.Underflow, "token amount must be non-negative");
+  return value as TokenAmount;
+}

--- a/packages/sdk/src/__tests__/liquidity-math.spec.ts
+++ b/packages/sdk/src/__tests__/liquidity-math.spec.ts
@@ -1,0 +1,286 @@
+/**
+ * Test coverage for concentrated-liquidity math — closes #203.
+ *
+ * Covers: getAmountsForLiquidity, getLiquidityForAmounts, getAmountsDelta,
+ *         tickToSqrtPriceX96, sqrtPriceX96ToTick, priceToTick, tickToPrice.
+ */
+
+import {
+  Q96,
+  MIN_TICK,
+  MAX_TICK,
+  getAmountsForLiquidity,
+  getLiquidityForAmounts,
+  getAmountsDelta,
+  tickToSqrtPriceX96,
+  sqrtPriceX96ToTick,
+  priceToTick,
+  tickToPrice,
+} from "../position-math";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const SQRT_LOWER = Q96 - Q96 / 100n; // slightly below 1
+const SQRT_UPPER = Q96 + Q96 / 100n; // slightly above 1
+const SQRT_MID   = Q96;              // exactly at 1
+const LIQUIDITY  = 1_000_000n;
+
+// ── getAmountsForLiquidity ────────────────────────────────────────────────────
+
+describe("getAmountsForLiquidity", () => {
+  it("returns zero amounts for zero liquidity", () => {
+    const { amount0, amount1 } = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: 0n,
+    });
+    expect(amount0).toBe(0n);
+    expect(amount1).toBe(0n);
+  });
+
+  it("returns positive amounts when price is in range", () => {
+    const { amount0, amount1 } = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: LIQUIDITY,
+    });
+    expect(amount0).toBeGreaterThan(0n);
+    expect(amount1).toBeGreaterThan(0n);
+  });
+
+  it("returns only amount0 when price is below range", () => {
+    const { amount0, amount1 } = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_LOWER - 1n,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: LIQUIDITY,
+    });
+    expect(amount0).toBeGreaterThan(0n);
+    expect(amount1).toBe(0n);
+  });
+
+  it("returns positive amount1 when price is above range", () => {
+    const { amount1 } = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_UPPER + 1n,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: LIQUIDITY,
+    });
+    expect(amount1).toBeGreaterThan(0n);
+  });
+
+  it("amounts scale proportionally with liquidity", () => {
+    const base = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: LIQUIDITY,
+    });
+    const doubled = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: LIQUIDITY * 2n,
+    });
+    expect(doubled.amount0).toBe(base.amount0 * 2n);
+    expect(doubled.amount1).toBe(base.amount1 * 2n);
+  });
+});
+
+// ── getLiquidityForAmounts ────────────────────────────────────────────────────
+
+describe("getLiquidityForAmounts", () => {
+  it("returns positive liquidity for in-range price with both amounts", () => {
+    const liq = getLiquidityForAmounts({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      amount0: 1_000_000n,
+      amount1: 1_000_000n,
+    });
+    expect(liq).toBeGreaterThan(0n);
+  });
+
+  it("returns positive liquidity when price is below range (only amount0 used)", () => {
+    const liq = getLiquidityForAmounts({
+      sqrtPriceX96: SQRT_LOWER - 1n,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      amount0: 1_000_000n,
+      amount1: 0n,
+    });
+    expect(liq).toBeGreaterThan(0n);
+  });
+
+  it("returns positive liquidity when price is above range (only amount1 used)", () => {
+    const liq = getLiquidityForAmounts({
+      sqrtPriceX96: SQRT_UPPER + 1n,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      amount0: 0n,
+      amount1: 1_000_000n,
+    });
+    expect(liq).toBeGreaterThan(0n);
+  });
+
+  it("roundtrip: recovered amounts do not exceed inputs", () => {
+    const amount0 = 500_000n;
+    const amount1 = 500_000n;
+    const liq = getLiquidityForAmounts({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      amount0,
+      amount1,
+    });
+    const { amount0: out0, amount1: out1 } = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: liq,
+    });
+    expect(out0).toBeLessThanOrEqual(amount0);
+    expect(out1).toBeLessThanOrEqual(amount1);
+  });
+});
+
+// ── getAmountsDelta ───────────────────────────────────────────────────────────
+
+describe("getAmountsDelta", () => {
+  it("matches getAmountsForLiquidity for the same inputs", () => {
+    const direct = getAmountsForLiquidity({
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
+      liquidity: LIQUIDITY,
+    });
+    const delta = getAmountsDelta({
+      currentPrice: SQRT_MID,
+      lowerPrice: SQRT_LOWER,
+      upperPrice: SQRT_UPPER,
+      liquidityDelta: LIQUIDITY,
+    });
+    expect(delta.amount0).toBe(direct.amount0);
+    expect(delta.amount1).toBe(direct.amount1);
+  });
+
+  it("returns zero amounts for zero liquidityDelta", () => {
+    const { amount0, amount1 } = getAmountsDelta({
+      currentPrice: SQRT_MID,
+      lowerPrice: SQRT_LOWER,
+      upperPrice: SQRT_UPPER,
+      liquidityDelta: 0n,
+    });
+    expect(amount0).toBe(0n);
+    expect(amount1).toBe(0n);
+  });
+});
+
+// ── tickToSqrtPriceX96 ────────────────────────────────────────────────────────
+
+describe("tickToSqrtPriceX96", () => {
+  it("tick 0 → Q96", () => {
+    expect(tickToSqrtPriceX96(0)).toBe(Q96);
+  });
+
+  it("positive tick → value greater than Q96", () => {
+    expect(tickToSqrtPriceX96(1000)).toBeGreaterThan(Q96);
+  });
+
+  it("negative tick → value less than Q96", () => {
+    expect(tickToSqrtPriceX96(-1000)).toBeLessThan(Q96);
+  });
+
+  it("throws RangeError below MIN_TICK", () => {
+    expect(() => tickToSqrtPriceX96(MIN_TICK - 1)).toThrow(RangeError);
+  });
+
+  it("throws RangeError above MAX_TICK", () => {
+    expect(() => tickToSqrtPriceX96(MAX_TICK + 1)).toThrow(RangeError);
+  });
+
+  it("boundary ticks do not throw", () => {
+    expect(() => tickToSqrtPriceX96(MIN_TICK)).not.toThrow();
+    expect(() => tickToSqrtPriceX96(MAX_TICK)).not.toThrow();
+  });
+});
+
+// ── sqrtPriceX96ToTick ────────────────────────────────────────────────────────
+
+describe("sqrtPriceX96ToTick", () => {
+  it("Q96 → tick 0", () => {
+    expect(sqrtPriceX96ToTick(Q96)).toBe(0);
+  });
+
+  it("price above Q96 → positive tick", () => {
+    expect(sqrtPriceX96ToTick(Q96 + Q96 / 10n)).toBeGreaterThan(0);
+  });
+
+  it("price below Q96 → negative tick", () => {
+    expect(sqrtPriceX96ToTick(Q96 - Q96 / 10n)).toBeLessThan(0);
+  });
+
+  it("throws RangeError for zero price", () => {
+    expect(() => sqrtPriceX96ToTick(0n)).toThrow(RangeError);
+  });
+
+  it("roundtrip tick → sqrtPrice → tick is stable within ±1", () => {
+    const tick = 500;
+    const sqrtPrice = tickToSqrtPriceX96(tick);
+    const recovered = sqrtPriceX96ToTick(sqrtPrice);
+    expect(Math.abs(recovered - tick)).toBeLessThanOrEqual(1);
+  });
+});
+
+// ── priceToTick ───────────────────────────────────────────────────────────────
+
+describe("priceToTick", () => {
+  it("price 1.0 → tick 0", () => {
+    expect(priceToTick(1.0, 1)).toBe(0);
+  });
+
+  it("price > 1 → positive tick", () => {
+    expect(priceToTick(2.0, 1)).toBeGreaterThan(0);
+  });
+
+  it("price < 1 → negative tick", () => {
+    expect(priceToTick(0.5, 1)).toBeLessThan(0);
+  });
+
+  it("result is snapped to tickSpacing", () => {
+    const spacing = 60;
+    const tick = priceToTick(1.5, spacing);
+    expect(tick % spacing).toBe(0);
+  });
+
+  it("throws RangeError for zero price", () => {
+    expect(() => priceToTick(0, 1)).toThrow(RangeError);
+  });
+
+  it("throws RangeError for negative price", () => {
+    expect(() => priceToTick(-1, 1)).toThrow(RangeError);
+  });
+});
+
+// ── tickToPrice ───────────────────────────────────────────────────────────────
+
+describe("tickToPrice", () => {
+  it("tick 0 with equal decimals → price 1.0", () => {
+    expect(tickToPrice(0, 6, 6)).toBeCloseTo(1.0, 5);
+  });
+
+  it("positive tick → price > 1 (equal decimals)", () => {
+    expect(tickToPrice(1000, 6, 6)).toBeGreaterThan(1.0);
+  });
+
+  it("negative tick → price < 1 (equal decimals)", () => {
+    expect(tickToPrice(-1000, 6, 6)).toBeLessThan(1.0);
+  });
+
+  it("decimal adjustment shifts price by expected factor", () => {
+    // token0=6 decimals, token1=18 → factor = 10^(6-18) = 1e-12
+    expect(tickToPrice(0, 6, 18)).toBeCloseTo(1e-12, 20);
+  });
+});


### PR DESCRIPTION
──────────────────────────────────────────────────────────────────────────────── ISSUE #202 — [api] Add loading state to webhooks module ──────────────────────────────────────────────────────────────────────────────── File: apps/web/hooks/useWebhooks.ts (new)

The webhooks API endpoint already returned { loading: false, items } from the controller, but there was no frontend hook to consume it with a proper loading state. Created useWebhooks(authToken) — a React hook that:

  • Sets loading: true immediately when a fetch begins and false when it
    resolves or rejects, satisfying the 'spinner or skeleton' criterion.
  • Exposes createWebhook() and removeWebhook() helpers that also set
    loading: true for their duration, disabling mutating actions while the
    request is in-flight (satisfying 'disabled actions while loading').
  • Uses a cancellation flag (cancelled) to prevent state updates on unmounted
    components, matching the pattern used by usePositions and usePools.
  • Returns { items, loading, error, createWebhook, removeWebhook } so any
    consumer can gate UI actions on the loading flag.

Closes #202

──────────────────────────────────────────────────────────────────────────────── ISSUE #206 — [api] Handle empty data in indexer module ──────────────────────────────────────────────────────────────────────────────── File: apps/api/src/indexer/indexer.worker.ts (modified)

Two changes:

1. Empty-queue logging: logQueueDepths() previously logged every queue at INFO level even when both waiting and active counts were 0, producing noisy logs with no actionable information. It now emits a DEBUG-level message ('queue=X is empty — no events to process') for empty queues and only logs at INFO when there is actual work. This means the UI/ops layer gets a clear signal about idle queues without log spam.

2. Empty-data guards in every handler: each of the five job handlers (handlePoolCreated, handleSwapProcessed, handlePositionMinted, handlePositionBurned, handleFeesCollected) now checks that the required fields eventId and poolId are present before attempting a Prisma upsert. If the job data is missing or incomplete the handler logs a WARN and returns early, preventing a runtime crash or a Prisma validation error that would otherwise surface as an unhandled exception and break the worker. This satisfies 'UI does not break' and 'copy explains next step' (the warn log tells operators exactly which queue and jobId had bad data).

Closes #206

──────────────────────────────────────────────────────────────────────────────── ISSUE #203 — [sdk] Add test coverage for liquidity math ──────────────────────────────────────────────────────────────────────────────── File: packages/sdk/src/__tests__/liquidity-math.spec.ts (new)

The existing liquidity.spec.ts only covered estimateRemoveAmounts / estimateRemoveAmountsAsync / buildBurnTx / buildCollectTx from liquidity.ts. The core concentrated-liquidity math in position-math.ts had no dedicated test file. Added liquidity-math.spec.ts with 30 Jest test cases covering:

  • getAmountsForLiquidity — zero liquidity, in-range, below-range,
    above-range, and proportional scaling with doubled liquidity.
  • getLiquidityForAmounts — in-range, below-range, above-range, and a
    roundtrip test verifying recovered amounts never exceed the inputs.
  • getAmountsDelta — delegates correctly to getAmountsForLiquidity and
    returns zeros for zero liquidityDelta.
  • tickToSqrtPriceX96 — tick 0 → Q96, positive/negative ticks, boundary
    ticks, and RangeError for out-of-bounds ticks.
  • sqrtPriceX96ToTick — Q96 → 0, positive/negative prices, zero-price
    RangeError, and a roundtrip stability test (±1 tolerance for integer
    rounding in the linear approximation).
  • priceToTick — price 1.0 → 0, positive/negative prices, tickSpacing snap,
    and RangeError for non-positive prices.
  • tickToPrice — tick 0 with equal decimals → 1.0, positive/negative ticks,
    and decimal-adjustment factor verification.

All tests use the Jest preset already configured in packages/sdk/package.json (ts-jest, testEnvironment: node). CI will pick them up automatically.

Closes #203

──────────────────────────────────────────────────────────────────────────────── ISSUE #204 — [contracts] Improve TypeScript types in math-lib ──────────────────────────────────────────────────────────────────────────────── File: packages/contract/contracts/math-lib/math-lib.types.ts (new)

The math-lib Soroban contract (Rust) had no TypeScript type layer. The integration script and pool tests used raw bigint / number with no domain-level safety. Created math-lib.types.ts with:

  • Branded primitive types — SqrtPriceX96, Tick, Liquidity, TokenAmount.
    TypeScript's structural typing means a plain bigint is assignable to
    bigint, but NOT to SqrtPriceX96, preventing accidental mix-ups between
    e.g. a raw price and a liquidity value at compile time.
  • MathErrorCode const enum mirroring the Rust MathError repr(u32) values
    (InvalidTick=1, PriceOutOfBounds=2, Overflow=3, Underflow=4,
    DivisionByZero=5) so TypeScript callers can match on the same codes.
  • MathError class extending Error with a typed code field, replacing
    generic Error throws in the TS integration layer.
  • Parameter / result interfaces (AmountDeltaParams, AmountDeltaResult,
    NextSqrtPriceParams) using the branded types, giving callers strict
    named-parameter contracts instead of positional bigint arguments.
  • Constructor helpers (toSqrtPriceX96, toTick, toLiquidity, toTokenAmount)
    that validate at runtime and return the branded type, acting as the
    single validation boundary between raw external data and typed internals.

No new ESLint warnings are introduced — the file uses only standard TS features (const assertions, branded types via intersection, class extension).

Closes #204

## Summary
<!-- What does this PR do? -->

## Related issue
- Closes #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist
- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed