### PR TITLE
fix(sdk): improve TypeScript types in liquidity math

### DIFF
--- a/apps/web/components/RemoveLiquidityPanel.tsx
+++ b/apps/web/components/RemoveLiquidityPanel.tsx
@@ -37,13 +37,13 @@ export function RemoveLiquidityPanel({ position, token0Symbol, token1Symbol, aut
     let cancelled = false;
     setEstimatesLoading(true);
     // Use async SDK method to allow UI to show loading state
-    estimateRemoveAmountsAsync(
-      position.liquidity,
+    estimateRemoveAmountsAsync({
+      liquidity: position.liquidity,
       pct,
-      position.poolCurrentPrice,
-      position.lowerTick,
-      position.upperTick
-    )
+      currentPrice: position.poolCurrentPrice,
+      lowerTick: position.lowerTick,
+      upperTick: position.upperTick,
+    })
       .then((r) => { if (!cancelled) setEstimates(r); })
       .catch(() => { if (!cancelled) setEstimates({ amount0: '0', amount1: '0' }); })
       .finally(() => { if (!cancelled) setEstimatesLoading(false); });

--- a/packages/sdk/src/__tests__/liquidity-math.spec.ts
+++ b/packages/sdk/src/__tests__/liquidity-math.spec.ts
@@ -157,9 +157,9 @@ describe("getAmountsDelta", () => {
       liquidity: LIQUIDITY,
     });
     const delta = getAmountsDelta({
-      currentPrice: SQRT_MID,
-      lowerPrice: SQRT_LOWER,
-      upperPrice: SQRT_UPPER,
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
       liquidityDelta: LIQUIDITY,
     });
     expect(delta.amount0).toBe(direct.amount0);
@@ -168,9 +168,9 @@ describe("getAmountsDelta", () => {
 
   it("returns zero amounts for zero liquidityDelta", () => {
     const { amount0, amount1 } = getAmountsDelta({
-      currentPrice: SQRT_MID,
-      lowerPrice: SQRT_LOWER,
-      upperPrice: SQRT_UPPER,
+      sqrtPriceX96: SQRT_MID,
+      sqrtPriceLowerX96: SQRT_LOWER,
+      sqrtPriceUpperX96: SQRT_UPPER,
       liquidityDelta: 0n,
     });
     expect(amount0).toBe(0n);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,7 @@ export { calculateSwapQuote, EMPTY_QUOTE, isEmptyQuote } from './quote';
 export type { SwapQuoteParams, SwapQuote, LocalSwapQuoteParams, LocalSwapQuote, PoolStateWithTicks } from './quote';
 
 export { buildBurnTx, buildCollectTx, estimateRemoveAmounts, estimateRemoveAmountsAsync } from './liquidity';
-export type { BurnTxParams, CollectTxParams, UnsignedTx, BurnUnsignedTx, CollectUnsignedTx, RemoveAmountsResult } from './liquidity';
+export type { BurnTxParams, CollectTxParams, UnsignedTx, BurnUnsignedTx, CollectUnsignedTx, RemoveAmountsResult, RemoveAmountsParams } from './liquidity';
 
 // #69 — Pool query helpers
 export { getPool, getPosition, getTick, EMPTY_POSITION_MESSAGE } from './queries';

--- a/packages/sdk/src/liquidity.ts
+++ b/packages/sdk/src/liquidity.ts
@@ -56,22 +56,54 @@ export function buildCollectTx(params: CollectTxParams): CollectUnsignedTx {
 }
 
 /**
+ * Parameters for estimating token amounts returned from a liquidity removal.
+ */
+export interface RemoveAmountsParams {
+  /** Current position liquidity as a decimal string. */
+  readonly liquidity: string;
+  /** Percentage of liquidity to remove (0–100). */
+  readonly pct: number;
+  /** Current pool price (token1/token0). */
+  readonly currentPrice: number;
+  /** Lower tick bound of the position. */
+  readonly lowerTick: number;
+  /** Upper tick bound of the position. */
+  readonly upperTick: number;
+}
+
+/**
  * Estimates token amounts returned for a given liquidity removal percentage.
  *
- * @param liquidity - Current position liquidity as a decimal string.
- * @param pct - Percentage of liquidity to remove (0–100).
- * @param currentPrice - Current pool price (token1/token0).
- * @param lowerTick - Lower tick bound of the position.
- * @param upperTick - Upper tick bound of the position.
+ * @param params - The removal parameters.
+ * @returns Estimated token amounts as fixed-point strings (7 decimals).
+ * @throws {RangeError} If `pct` is outside the 0–100 range.
+ * @throws {RangeError} If `liquidity` cannot be parsed as a finite number.
+ *
+ * @example
+ * ```ts
+ * const result = estimateRemoveAmounts({
+ *   liquidity: '1000000',
+ *   pct: 50,
+ *   currentPrice: 1.5,
+ *   lowerTick: -1000,
+ *   upperTick: 1000,
+ * });
+ * ```
  */
-export function estimateRemoveAmounts(
-  liquidity: string,
-  pct: number,
-  currentPrice: number,
-  lowerTick: number,
-  upperTick: number,
-): RemoveAmountsResult {
+export function estimateRemoveAmounts({
+  liquidity,
+  pct,
+  currentPrice,
+  lowerTick,
+  upperTick,
+}: RemoveAmountsParams): RemoveAmountsResult {
+  if (pct < 0 || pct > 100) {
+    throw new RangeError('pct must be between 0 and 100');
+  }
   const liq = parseFloat(liquidity);
+  if (!Number.isFinite(liq)) {
+    throw new RangeError('liquidity must be a finite number');
+  }
   const fraction = pct / 100;
 
   // Simplified geometric approximation — replace with full tick math in SDK v1
@@ -98,22 +130,20 @@ export function estimateRemoveAmounts(
 }
 
 /**
- * Async version of `estimateRemoveAmounts` that returns a Promise and can be
- * awaited by UIs that want to show a loading state while the math runs.
+ * Async version of {@link estimateRemoveAmounts} that returns a Promise and
+ * can be awaited by UIs that want to show a loading state while the math runs.
  * The computation is lightweight but wrapped in a microtask to allow
  * consumers to display spinners/skeletons.
+ *
+ * @param params - The removal parameters (same as {@link estimateRemoveAmounts}).
  */
 export async function estimateRemoveAmountsAsync(
-  liquidity: string,
-  pct: number,
-  currentPrice: number,
-  lowerTick: number,
-  upperTick: number,
+  params: RemoveAmountsParams,
 ): Promise<RemoveAmountsResult> {
   return new Promise((resolve) => {
     // Defer to next tick so callers can render loading UI
     Promise.resolve().then(() => {
-      resolve(estimateRemoveAmounts(liquidity, pct, currentPrice, lowerTick, upperTick));
+      resolve(estimateRemoveAmounts(params));
     });
   });
 }

--- a/packages/sdk/src/position-math.ts
+++ b/packages/sdk/src/position-math.ts
@@ -44,15 +44,15 @@ export function tickToPrice(
 }
 
 export interface AmountsForLiquidityParams {
-  sqrtPriceX96: bigint;
-  sqrtPriceLowerX96: bigint;
-  sqrtPriceUpperX96: bigint;
-  liquidity: bigint;
+  readonly sqrtPriceX96: bigint;
+  readonly sqrtPriceLowerX96: bigint;
+  readonly sqrtPriceUpperX96: bigint;
+  readonly liquidity: bigint;
 }
 
 export interface AmountsResult {
-  amount0: bigint;
-  amount1: bigint;
+  readonly amount0: bigint;
+  readonly amount1: bigint;
 }
 
 /**
@@ -92,17 +92,13 @@ export function getAmountsForLiquidity({
 }
 
 export interface LiquidityForAmountsParams {
-  sqrtPriceX96: bigint;
-  sqrtPriceLowerX96: bigint;
-  sqrtPriceUpperX96: bigint;
-  amount0: bigint;
-  amount1: bigint;
+  readonly sqrtPriceX96: bigint;
+  readonly sqrtPriceLowerX96: bigint;
+  readonly sqrtPriceUpperX96: bigint;
+  readonly amount0: bigint;
+  readonly amount1: bigint;
 }
 
-/**
- * Returns the maximum liquidity achievable for the given token amounts and price range.
- * Mirrors the inverse of amounts_for_liquidity.
- */
 /**
  * Returns the maximum liquidity achievable for the given token amounts and price range.
  *
@@ -142,33 +138,43 @@ export function getLiquidityForAmounts({
   }
 }
 
+/**
+ * Parameters for computing token amounts returned from a liquidity burn.
+ *
+ * All price fields are **Q64.96 fixed-point sqrt prices** — the same
+ * representation used on-chain and by {@link AmountsForLiquidityParams}.
+ */
 export interface AmountsDeltaParams {
-  currentPrice: bigint;   // sqrtPriceX96
-  lowerPrice: bigint;     // sqrtPriceLowerX96
-  upperPrice: bigint;     // sqrtPriceUpperX96
-  liquidityDelta: bigint; // liquidity to burn (positive)
+  /** Current sqrt price in Q64.96 format (sqrtPriceX96). */
+  readonly sqrtPriceX96: bigint;
+  /** Lower bound sqrt price in Q64.96 format. */
+  readonly sqrtPriceLowerX96: bigint;
+  /** Upper bound sqrt price in Q64.96 format. */
+  readonly sqrtPriceUpperX96: bigint;
+  /** Liquidity delta to burn — must be non-negative. */
+  readonly liquidityDelta: bigint;
 }
 
 /**
  * Returns token amounts returned for a partial or full burn.
  * Equivalent to calling getAmountsForLiquidity with liquidityDelta.
  *
- * @param params.currentPrice - current sqrtPrice (Q64.96)
- * @param params.lowerPrice - lower sqrtPrice (Q64.96)
- * @param params.upperPrice - upper sqrtPrice (Q64.96)
+ * @param params.sqrtPriceX96 - current sqrtPrice (Q64.96)
+ * @param params.sqrtPriceLowerX96 - lower sqrtPrice (Q64.96)
+ * @param params.sqrtPriceUpperX96 - upper sqrtPrice (Q64.96)
  * @param params.liquidityDelta - liquidity to burn (bigint)
  * @returns Object with `amount0` and `amount1` as bigint
  */
 export function getAmountsDelta({
-  currentPrice,
-  lowerPrice,
-  upperPrice,
+  sqrtPriceX96,
+  sqrtPriceLowerX96,
+  sqrtPriceUpperX96,
   liquidityDelta,
 }: AmountsDeltaParams): AmountsResult {
   return getAmountsForLiquidity({
-    sqrtPriceX96: currentPrice,
-    sqrtPriceLowerX96: lowerPrice,
-    sqrtPriceUpperX96: upperPrice,
+    sqrtPriceX96,
+    sqrtPriceLowerX96,
+    sqrtPriceUpperX96,
     liquidity: liquidityDelta,
   });
 }


### PR DESCRIPTION
Closes #237

## Changes

### 1. Rename `AmountsDeltaParams` fields for consistency
The `AmountsDeltaParams` interface used `currentPrice`, `lowerPrice`, `upperPrice` which was inconsistent with `AmountsForLiquidityParams` and `LiquidityForAmountsParams` that both use `sqrtPriceX96`, `sqrtPriceLowerX96`, `sqrtPriceUpperX96`. All three interfaces now share the same naming convention.

### 2. Add `readonly` to all interfaces
All fields in `AmountsForLiquidityParams`, `AmountsResult`, `LiquidityForAmountsParams`, and `AmountsDeltaParams` are now `readonly`.

### 3. Add `RemoveAmountsParams` interface
Extracted the 5 positional parameters of `estimateRemoveAmounts` into a typed `RemoveAmountsParams` interface with JSDoc. `estimateRemoveAmountsAsync` now also accepts this interface.

### 4. Add input validation
- `estimateRemoveAmounts` now throws `RangeError` if `pct` is outside 0–100
- `estimateRemoveAmounts` now throws `RangeError` if `liquidity` cannot be parsed as a finite number

### 5. Improve JSDoc
- Added `@throws`, `@example`, and `{@link}` references
- Removed duplicate JSDoc block on `getLiquidityForAmounts`
- Added `@param` descriptions with Q64.96 format notes

### Files changed
- `packages/sdk/src/position-math.ts` — renamed fields, readonly, JSDoc
- `packages/sdk/src/liquidity.ts` — RemoveAmountsParams, validation, JSDoc
- `packages/sdk/src/index.ts` — export RemoveAmountsParams
- `apps/web/components/RemoveLiquidityPanel.tsx` — updated caller
- `packages/sdk/src/__tests__/liquidity-math.spec.ts` — updated test field names