### PR TITLE
fix: handle portfolio empty states

### DIFF
--- a/apps/web/__tests__/PortfolioPage.test.tsx
+++ b/apps/web/__tests__/PortfolioPage.test.tsx
@@ -203,7 +203,38 @@ describe("PortfolioPage", () => {
     const PortfolioPage = await importPage();
     render(<PortfolioPage />);
 
-    expect(screen.getByText("No positions yet.")).toBeInTheDocument();
+    expect(screen.getByText("You have no active positions yet.")).toBeInTheDocument();
+    expect(screen.getByText("Add liquidity to a pool to get started.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Browse pools" })).toBeInTheDocument();
+  });
+
+  it("keeps a first-position next step when showing all positions with no data", async () => {
+    const PortfolioPage = await importPage();
+    render(<PortfolioPage />);
+
+    const toggle = screen.getByRole("switch", { name: /show closed/i });
+    fireEvent.click(toggle);
+
+    expect(screen.getByText("You have no positions yet.")).toBeInTheDocument();
+    expect(screen.getByText("Add liquidity to a pool to create your first position.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Browse pools" })).toBeInTheDocument();
+  });
+
+  it("explains the next step when there are closed positions but no active positions", async () => {
+    const closedPos = makePosition({ id: "pos-closed", status: "closed", closedAt: 1_700_000_000 });
+    mockUsePortfolio.mockReturnValue({
+      active: [],
+      closed: [closedPos],
+      loading: false,
+      refresh: mockRefresh,
+      totalValueUsd: 0,
+    });
+
+    const PortfolioPage = await importPage();
+    render(<PortfolioPage />);
+
+    expect(screen.getByText("No active positions found.")).toBeInTheDocument();
+    expect(screen.getByText("Add liquidity to open a new position, or show closed positions to review past ones.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Browse pools" })).toBeInTheDocument();
   });
 

--- a/apps/web/app/portfolio/page.tsx
+++ b/apps/web/app/portfolio/page.tsx
@@ -74,6 +74,7 @@ export default function PortfolioPage() {
   if (!address) return null;
 
   const positions = showClosed ? [...active, ...closed] : active;
+  const hasAnyPositions = active.length + closed.length > 0;
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-6 sm:py-10">
@@ -127,8 +128,25 @@ export default function PortfolioPage() {
         <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
           {showClosed ? (
             <>
-              <p className="text-sm text-zinc-500">No closed positions found.</p>
-              <p className="text-xs text-zinc-400">Positions you close will appear here.</p>
+              <p className="text-sm text-zinc-500">You have no positions yet.</p>
+              <p className="text-xs text-zinc-400">Add liquidity to a pool to create your first position.</p>
+              <Link
+                href="/pools"
+                className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+              >
+                Browse pools
+              </Link>
+            </>
+          ) : hasAnyPositions ? (
+            <>
+              <p className="text-sm text-zinc-500">No active positions found.</p>
+              <p className="text-xs text-zinc-400">Add liquidity to open a new position, or show closed positions to review past ones.</p>
+              <Link
+                href="/pools"
+                className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+              >
+                Browse pools
+              </Link>
             </>
           ) : (
             <>


### PR DESCRIPTION
## Summary
- Improves `PortfolioPage` empty states so the all-positions view still gives a first-position next step when there is no data.
- Adds a clearer active-empty state for wallets that only have closed positions.
- Updates PortfolioPage tests for the current empty-state copy and the new edge cases.

## Related issue
- Closes #221

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Validation
- `corepack pnpm --filter web test -- PortfolioPage`
- `corepack pnpm --dir apps/web exec eslint app/portfolio/page.tsx __tests__/PortfolioPage.test.tsx`
- `git diff --check`

## Build note
- `corepack pnpm --filter web build` is currently blocked locally by existing unrelated workspace issues: duplicate `raw` in `packages/sdk/src/queries.ts`, missing Radix deps from `packages/ui`, and missing `PriceImpactBadge` export from `@swyft/ui`.

## Checklist
- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [ ] Docs updated if needed