### PR TITLE
docs(web): add JSDoc to SwapWidget exported API (#225)

### DIFF
--- a/apps/web/components/SwapWidget.tsx
+++ b/apps/web/components/SwapWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 // import { SwapInput, PriceImpactBadge, SlippagePanel, type TokenPair, type Token } from "@swyft/ui"; // TODO: export these from @swyft/ui
 import { useTokens, useRecentTokens, usePoolId } from "@/hooks/useTokens";
 import { useSwapQuote } from "@/hooks/useSwapQuote";
@@ -217,7 +217,15 @@ interface Props {
  * Handles token selection, quote fetching, slippage configuration, and
  * swap confirmation in a single composable component.
  *
- * @param props - {@link Props}
+ * @param props - The configuration props for the SwapWidget component.
+ * @param props.wallet - Current wallet state. Pass `{ address: null }` when no wallet is
+ *   connected — the widget will render a "Connect wallet" prompt.
+ * @param props.onTokenInChange - Callback invoked when the user selects a new "token in".
+ *   Receives `null` when the selection is cleared.
+ * @param props.onTokenOutChange - Callback invoked when the user selects a new "token out".
+ *   Receives `null` when the selection is cleared.
+ * @param props.onSwapSuccess - Callback invoked after a swap transaction is confirmed and the
+ *   confirmation modal is dismissed. Use this to refresh balances or history.
  * @returns A React element containing the full swap UI, or a loading
  *   skeleton / error state while token data is being fetched.
  *
@@ -234,7 +242,7 @@ export function SwapWidget({
   onTokenInChange,
   onTokenOutChange,
   onSwapSuccess,
-}: Props) {
+}: Props): React.JSX.Element {
   const { tokens, loading: tokensLoading, error: tokensError } = useTokens();
   const { recentIds: _recentIds, pushRecent } = useRecentTokens();
   const [pair, setPair] = useState<TokenPair>({ tokenIn: null, tokenOut: null });


### PR DESCRIPTION
Closes #225

---

## PR Description

### Summary

Adds complete JSDoc documentation to the exported `SwapWidget` component API, closing issue #225.

### Changes

**[`apps/web/components/SwapWidget.tsx`](file:///c:/Users/godzi/Documents/Swyft/apps/web/components/SwapWidget.tsx)**
- Expanded the `@param props` tag into **individual `@param props.*` tags** for each prop:
  - `props.wallet` — documents the wallet state shape and the disconnected case
  - `props.onTokenInChange` — documents the callback and nullable argument
  - `props.onTokenOutChange` — documents the callback and nullable argument
  - `props.onSwapSuccess` — documents when it fires and suggested use case
- Added an explicit `React.JSX.Element` **return type annotation** to the function signature
- Retained the existing `@returns` description and `@example` block
- Added `React` as a named import to support the explicit return type annotation

### Acceptance Criteria

- [x] Params documented (`wallet`, `onTokenInChange`, `onTokenOutChange`, `onSwapSuccess`)
- [x] Return type described (`React.JSX.Element`)

### Testing

- ESLint confirms 0 errors in `SwapWidget.tsx` (1 pre-existing unrelated warning)
- No functional code changes — documentation only
