### PR TITLE
fix(sdk): update liquidity spec to use object-based RemoveAmountsParams API

### DIFF
--- a/packages/sdk/src/__tests__/liquidity.spec.ts
+++ b/packages/sdk/src/__tests__/liquidity.spec.ts
@@ -3,6 +3,7 @@ import {
   estimateRemoveAmountsAsync,
   buildBurnTx,
   buildCollectTx,
+  RemoveAmountsParams,
 } from "../liquidity";
 
 // ---------------------------------------------------------------------------
@@ -14,49 +15,69 @@ describe("estimateRemoveAmounts", () => {
   const TICK_LOWER = -100;
   const TICK_UPPER = 100;
 
+  const base: RemoveAmountsParams = {
+    liquidity: LIQUIDITY,
+    pct: 100,
+    currentPrice: 1.0,
+    lowerTick: TICK_LOWER,
+    upperTick: TICK_UPPER,
+  };
+
   it("returns non-negative amounts when price is within range", () => {
-    const result = estimateRemoveAmounts(LIQUIDITY, 100, 1.0, TICK_LOWER, TICK_UPPER);
+    const result = estimateRemoveAmounts(base);
     expect(parseFloat(result.amount0)).toBeGreaterThanOrEqual(0);
     expect(parseFloat(result.amount1)).toBeGreaterThanOrEqual(0);
   });
 
   it("returns only amount0 when price is below lower tick", () => {
     // price well below lower tick → all token0
-    const result = estimateRemoveAmounts(LIQUIDITY, 100, 0.00001, TICK_LOWER, TICK_UPPER);
+    const result = estimateRemoveAmounts({ ...base, currentPrice: 0.00001 });
     expect(parseFloat(result.amount0)).toBeGreaterThan(0);
     expect(parseFloat(result.amount1)).toBe(0);
   });
 
   it("returns only amount1 when price is above upper tick", () => {
     // price well above upper tick → all token1
-    const result = estimateRemoveAmounts(LIQUIDITY, 100, 100000, TICK_LOWER, TICK_UPPER);
+    const result = estimateRemoveAmounts({ ...base, currentPrice: 100000 });
     expect(parseFloat(result.amount0)).toBe(0);
     expect(parseFloat(result.amount1)).toBeGreaterThan(0);
   });
 
   it("scales linearly with removal percentage", () => {
-    const full = estimateRemoveAmounts(LIQUIDITY, 100, 1.0, TICK_LOWER, TICK_UPPER);
-    const half = estimateRemoveAmounts(LIQUIDITY, 50, 1.0, TICK_LOWER, TICK_UPPER);
+    const full = estimateRemoveAmounts({ ...base, pct: 100 });
+    const half = estimateRemoveAmounts({ ...base, pct: 50 });
     expect(parseFloat(full.amount0)).toBeCloseTo(parseFloat(half.amount0) * 2, 5);
     expect(parseFloat(full.amount1)).toBeCloseTo(parseFloat(half.amount1) * 2, 5);
   });
 
   it("returns zero amounts for 0% removal", () => {
-    const result = estimateRemoveAmounts(LIQUIDITY, 0, 1.0, TICK_LOWER, TICK_UPPER);
+    const result = estimateRemoveAmounts({ ...base, pct: 0 });
     expect(parseFloat(result.amount0)).toBe(0);
     expect(parseFloat(result.amount1)).toBe(0);
   });
 
   it("returns amounts with 7 decimal places", () => {
-    const result = estimateRemoveAmounts(LIQUIDITY, 50, 1.0, TICK_LOWER, TICK_UPPER);
+    const result = estimateRemoveAmounts({ ...base, pct: 50 });
     expect(result.amount0).toMatch(/^\d+\.\d{7}$/);
     expect(result.amount1).toMatch(/^\d+\.\d{7}$/);
   });
 
   it("handles zero liquidity without throwing", () => {
-    const result = estimateRemoveAmounts("0", 100, 1.0, TICK_LOWER, TICK_UPPER);
+    const result = estimateRemoveAmounts({ ...base, liquidity: "0" });
     expect(parseFloat(result.amount0)).toBe(0);
     expect(parseFloat(result.amount1)).toBe(0);
+  });
+
+  it("throws RangeError when pct is below 0", () => {
+    expect(() => estimateRemoveAmounts({ ...base, pct: -1 })).toThrow(RangeError);
+  });
+
+  it("throws RangeError when pct is above 100", () => {
+    expect(() => estimateRemoveAmounts({ ...base, pct: 101 })).toThrow(RangeError);
+  });
+
+  it("throws RangeError for non-finite liquidity", () => {
+    expect(() => estimateRemoveAmounts({ ...base, liquidity: "NaN" })).toThrow(RangeError);
   });
 });
 
@@ -65,14 +86,28 @@ describe("estimateRemoveAmounts", () => {
 // ---------------------------------------------------------------------------
 
 describe("estimateRemoveAmountsAsync", () => {
+  const params: RemoveAmountsParams = {
+    liquidity: "500000",
+    pct: 75,
+    currentPrice: 1.0,
+    lowerTick: -200,
+    upperTick: 200,
+  };
+
   it("resolves to the same result as the sync version", async () => {
-    const sync = estimateRemoveAmounts("500000", 75, 1.0, -200, 200);
-    const async_ = await estimateRemoveAmountsAsync("500000", 75, 1.0, -200, 200);
+    const sync = estimateRemoveAmounts(params);
+    const async_ = await estimateRemoveAmountsAsync(params);
     expect(async_).toEqual(sync);
   });
 
   it("returns a Promise", () => {
-    const result = estimateRemoveAmountsAsync("1000000", 100, 1.0, -100, 100);
+    const result = estimateRemoveAmountsAsync({
+      liquidity: "1000000",
+      pct: 100,
+      currentPrice: 1.0,
+      lowerTick: -100,
+      upperTick: 100,
+    });
     expect(result).toBeInstanceOf(Promise);
   });
 });


### PR DESCRIPTION
## Summary

- Updates `packages/sdk/src/__tests__/liquidity.spec.ts` to use the `RemoveAmountsParams` object-based API, matching the implementation refactored in #282
- Imports and uses the `RemoveAmountsParams` type explicitly so the call sites are type-checked
- Adds three additional edge-case tests (pct < 0, pct > 101, non-finite liquidity)

The previous test file called `estimateRemoveAmounts` and `estimateRemoveAmountsAsync` with positional arguments, causing TypeScript errors after the function signatures were updated to accept a params object.

## Test plan

- [ ] `pnpm test` in `packages/sdk` passes with no TypeScript errors
- [ ] No new ESLint warnings introduced

Closes #257