### PR TITLE
fix(contracts): handle empty data in math-lib TypeScript layer

### DIFF
--- a/packages/contract/contracts/math-lib/math-lib.types.ts
+++ b/packages/contract/contracts/math-lib/math-lib.types.ts
@@ -97,3 +97,136 @@ export function toTokenAmount(value: bigint): TokenAmount {
   if (value < 0n) throw new MathError(MathErrorCode.Underflow, "token amount must be non-negative");
   return value as TokenAmount;
 }
+
+// ── Empty-data handling ───────────────────────────────────────────────────────
+
+/**
+ * Discriminated union returned by safe math helpers.
+ * Use `result.ok` to branch between the value and the human-readable message.
+ *
+ * @example
+ * ```ts
+ * const result = safeSqrtPriceX96(rawPrice);
+ * if (!result.ok) {
+ *   // Show result.message in the UI — it already explains the next step.
+ *   return;
+ * }
+ * // result.value is a validated SqrtPriceX96
+ * ```
+ */
+export type MathLibResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly message: string };
+
+/** User-facing messages for empty / invalid math-lib inputs. */
+export const MATH_LIB_MESSAGES = {
+  missingPrice: "Price data is not available yet. Wait for the pool to initialise, then try again.",
+  missingLiquidity: "Liquidity data is missing. Refresh the page to reload pool state.",
+  missingTick: "Tick data is unavailable. Ensure the pool is active before proceeding.",
+  missingAmount: "Token amount is required. Enter a value greater than zero to continue.",
+  invalidParams: "One or more calculation inputs are empty or invalid. Check your inputs and try again.",
+} as const;
+
+/**
+ * Returns `true` when `value` is `null`, `undefined`, or (for bigint) `0n`.
+ * Use this guard before passing data from the network/store to the math helpers.
+ */
+export function isEmpty(value: bigint | number | null | undefined): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "bigint") return value === 0n;
+  return false;
+}
+
+/**
+ * Safely wraps {@link toSqrtPriceX96}.
+ * Returns a {@link MathLibResult} instead of throwing, so callers can display
+ * the `.message` in the UI rather than catching exceptions.
+ */
+export function safeSqrtPriceX96(value: bigint | null | undefined): MathLibResult<SqrtPriceX96> {
+  if (isEmpty(value)) {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingPrice };
+  }
+  try {
+    return { ok: true, value: toSqrtPriceX96(value as bigint) };
+  } catch {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingPrice };
+  }
+}
+
+/**
+ * Safely wraps {@link toTick}.
+ * Returns a {@link MathLibResult} instead of throwing.
+ */
+export function safeTick(value: number | null | undefined): MathLibResult<Tick> {
+  if (value === null || value === undefined) {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingTick };
+  }
+  try {
+    return { ok: true, value: toTick(value) };
+  } catch {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingTick };
+  }
+}
+
+/**
+ * Safely wraps {@link toLiquidity}.
+ * Returns a {@link MathLibResult} instead of throwing.
+ */
+export function safeLiquidity(value: bigint | null | undefined): MathLibResult<Liquidity> {
+  if (value === null || value === undefined) {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingLiquidity };
+  }
+  try {
+    return { ok: true, value: toLiquidity(value) };
+  } catch {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingLiquidity };
+  }
+}
+
+/**
+ * Safely wraps {@link toTokenAmount}.
+ * Returns a {@link MathLibResult} instead of throwing.
+ */
+export function safeTokenAmount(value: bigint | null | undefined): MathLibResult<TokenAmount> {
+  if (value === null || value === undefined) {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingAmount };
+  }
+  try {
+    return { ok: true, value: toTokenAmount(value) };
+  } catch {
+    return { ok: false, message: MATH_LIB_MESSAGES.missingAmount };
+  }
+}
+
+/**
+ * Validates all fields of an {@link AmountDeltaParams} object, returning a
+ * {@link MathLibResult} with the fully-typed params or a descriptive message.
+ *
+ * Callers can spread the `.value` directly into the math function once the
+ * result is confirmed ok.
+ */
+export function safeAmountDeltaParams(
+  raw: Partial<Record<keyof AmountDeltaParams, bigint | null | undefined>>,
+): MathLibResult<AmountDeltaParams> {
+  const liquidity = safeLiquidity(raw.liquidity ?? null);
+  if (!liquidity.ok) return liquidity;
+
+  const sqrtLower = safeSqrtPriceX96(raw.sqrtPriceLowerX96 ?? null);
+  if (!sqrtLower.ok) return sqrtLower;
+
+  const sqrtUpper = safeSqrtPriceX96(raw.sqrtPriceUpperX96 ?? null);
+  if (!sqrtUpper.ok) return sqrtUpper;
+
+  const sqrtCurrent = safeSqrtPriceX96(raw.sqrtPriceCurrentX96 ?? null);
+  if (!sqrtCurrent.ok) return sqrtCurrent;
+
+  return {
+    ok: true,
+    value: {
+      liquidity: liquidity.value,
+      sqrtPriceLowerX96: sqrtLower.value,
+      sqrtPriceUpperX96: sqrtUpper.value,
+      sqrtPriceCurrentX96: sqrtCurrent.value,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds null/undefined-safe helpers to `packages/contract/contracts/math-lib/math-lib.types.ts` so callers never need to catch raw exceptions when pool state is incomplete
- `MathLibResult<T>`: discriminated union `{ ok, value } | { ok, message }` — callers branch on `result.ok` instead of try/catch
- `MATH_LIB_MESSAGES`: human-readable copy that explains the next step for each error case (missing price, liquidity, tick, amount)
- `isEmpty()`: guard for `null | undefined | 0n` bigint values
- `safeSqrtPriceX96`, `safeTick`, `safeLiquidity`, `safeTokenAmount`: non-throwing wrappers for the existing constructor helpers
- `safeAmountDeltaParams()`: validates a full `AmountDeltaParams` record and surfaces the first descriptive failure message

When any input is missing the UI receives a message string instead of an unhandled exception, so the page stays functional and guides the user to the next step.

## Test plan

- [ ] TypeScript compiles without errors in `packages/contract`
- [ ] Calling `safeSqrtPriceX96(null)` returns `{ ok: false, message: "..." }` — UI does not break
- [ ] Error messages contain actionable copy explaining the next step

Closes #254