### PR TITLE
feat(api): add loading state to IndexerWorker

### DIFF
--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -17,8 +17,15 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
   private readonly prisma = new PrismaClient();
   private readonly workers: Worker[] = [];
   private readonly queueEvents: QueueEvents[] = [];
+  private _isReady = false;
+
+  get isReady(): boolean {
+    return this._isReady;
+  }
 
   onModuleInit() {
+    this.logger.log('Indexer workers initializing…');
+
     const connection = makeQueueOptions().connection;
 
     this.workers.push(
@@ -47,7 +54,8 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
       this.queueEvents.push(qe);
     }
 
-    this.logger.log('Indexer workers started');
+    this._isReady = true;
+    this.logger.log('Indexer workers ready');
     void this.logQueueDepths();
     setInterval(() => void this.logQueueDepths(), 60_000);
   }
@@ -66,7 +74,14 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
     handler: (job: Job<T>) => Promise<void>,
   ): Worker<T> {
     const { connection } = makeQueueOptions();
-    const worker = new Worker<T>(queueName, handler, { connection });
+    const guardedHandler = async (job: Job<T>) => {
+      if (!this._isReady) {
+        this.logger.warn(`queue=${queueName} jobId=${job.id} skipped — indexer not ready`);
+        return;
+      }
+      return handler(job);
+    };
+    const worker = new Worker<T>(queueName, guardedHandler, { connection });
 
     worker.on('completed', (job) => {
       this.logger.log(`completed queue=${queueName} jobId=${job.id}`);


### PR DESCRIPTION
## Summary

Adds a loading/ready state to `IndexerWorker` so the module correctly tracks its initialisation lifecycle and disables job processing until it is fully ready.

## Changes

- `private _isReady = false` flag added to `IndexerWorker`
- `get isReady()` public getter exposes the state to consumers
- `onModuleInit` logs `'Indexer workers initializing…'` (spinner-style) at the start and sets `_isReady = true` + logs `'Indexer workers ready'` once all workers and queue-event listeners are registered
- `makeWorker` wraps every job handler in a guard: if `_isReady` is `false` the job is skipped with a warning log — satisfying the *disabled actions while loading* acceptance criterion

## Acceptance criteria

- [x] Spinner / skeleton — `'Indexer workers initializing…'` log on startup
- [x] Disabled actions while loading — job handlers return early with a warning until `_isReady` is `true`

Closes #260