### PR TITLE
feat: implement four onboarding issues (#217, #218, #219, #227)

### DIFF
--- a/apps/api/src/seed.spec.ts
+++ b/apps/api/src/seed.spec.ts
@@ -51,10 +51,10 @@ beforeEach(() => {
 
 describe('prisma seed', () => {
   async function runSeed() {
-    // Re-require each time so module-level code (main()) runs fresh
+    // Re-require each time so the seed module re-executes with a fresh PrismaClient
     jest.resetModules();
 
-    // Re-apply mock after resetModules
+    // Re-apply mock after resetModules so the freshly-imported module gets the mock
     jest.mock('@prisma/client', () => ({
       PrismaClient: jest.fn().mockImplementation(() => ({
         token: { upsert: mockUpsert },
@@ -66,10 +66,10 @@ describe('prisma seed', () => {
       })),
     }));
 
-    // Dynamically import so the top-level main() call executes
-    await import('../../../../prisma/seed');
-    // Allow all pending promises to settle
-    await new Promise((r) => setImmediate(r));
+    // Import the module and explicitly call main() — the require.main === module
+    // guard in seed.ts prevents main() from auto-running during import in tests.
+    const { main } = await import('../../../../prisma/seed');
+    await main();
   }
 
   it('upserts USDC token with correct address', async () => {

--- a/packages/sdk/src/__tests__/swap.spec.ts
+++ b/packages/sdk/src/__tests__/swap.spec.ts
@@ -1,0 +1,90 @@
+import {
+  buildSwapTx,
+  toStellarAddress,
+  toRawAmount,
+  toXdrBase64,
+} from "../swap";
+
+const POOL  = toStellarAddress("CPOOL000000000000000000000000000000000000000000000000000A");
+const TOKEN_IN  = toStellarAddress("CTOKENIN0000000000000000000000000000000000000000000000000");
+const TOKEN_OUT = toStellarAddress("CTOKENOUT000000000000000000000000000000000000000000000000");
+const OWNER = toStellarAddress("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
+const AMOUNT_IN  = toRawAmount("1000000");
+const MIN_OUT    = toRawAmount("990000");
+
+describe("buildSwapTx", () => {
+  it("returns type 'swap'", () => {
+    const tx = buildSwapTx({
+      poolId: POOL,
+      tokenInId: TOKEN_IN,
+      tokenOutId: TOKEN_OUT,
+      amountIn: AMOUNT_IN,
+      minimumReceived: MIN_OUT,
+      ownerAddress: OWNER,
+    });
+    expect(tx.type).toBe("swap");
+  });
+
+  it("returns a non-empty xdr string", () => {
+    const tx = buildSwapTx({
+      poolId: POOL,
+      tokenInId: TOKEN_IN,
+      tokenOutId: TOKEN_OUT,
+      amountIn: AMOUNT_IN,
+      minimumReceived: MIN_OUT,
+      ownerAddress: OWNER,
+    });
+    expect(typeof tx.xdr).toBe("string");
+    expect(tx.xdr.length).toBeGreaterThan(0);
+  });
+
+  it("encodes all params inside the xdr payload", () => {
+    const tx = buildSwapTx({
+      poolId: POOL,
+      tokenInId: TOKEN_IN,
+      tokenOutId: TOKEN_OUT,
+      amountIn: AMOUNT_IN,
+      minimumReceived: MIN_OUT,
+      ownerAddress: OWNER,
+    });
+    const decoded = atob(tx.xdr);
+    const payload = JSON.parse(decoded);
+    expect(payload.op).toBe("swap");
+    expect(payload.poolId).toBe(POOL);
+    expect(payload.tokenInId).toBe(TOKEN_IN);
+    expect(payload.tokenOutId).toBe(TOKEN_OUT);
+    expect(payload.amountIn).toBe(AMOUNT_IN);
+    expect(payload.minimumReceived).toBe(MIN_OUT);
+    expect(payload.ownerAddress).toBe(OWNER);
+  });
+
+  it("produces a different xdr for different amountIn values", () => {
+    const params = {
+      poolId: POOL,
+      tokenInId: TOKEN_IN,
+      tokenOutId: TOKEN_OUT,
+      amountIn: AMOUNT_IN,
+      minimumReceived: MIN_OUT,
+      ownerAddress: OWNER,
+    };
+    const tx1 = buildSwapTx(params);
+    const tx2 = buildSwapTx({ ...params, amountIn: toRawAmount("5000000") });
+    expect(tx1.xdr).not.toBe(tx2.xdr);
+  });
+});
+
+describe("cast helpers", () => {
+  it("toStellarAddress returns the same string value", () => {
+    const addr = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ";
+    expect(toStellarAddress(addr)).toBe(addr);
+  });
+
+  it("toRawAmount returns the same string value", () => {
+    expect(toRawAmount("9999")).toBe("9999");
+  });
+
+  it("toXdrBase64 returns the same string value", () => {
+    const b64 = btoa("hello");
+    expect(toXdrBase64(b64)).toBe(b64);
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,5 +9,5 @@ export { getPool, getPosition, getPositionWithLoading, getTick, EMPTY_POSITION_M
 export type { PoolState, PositionState, TickState } from './types';
 export { SwyftRpcError } from './types';
 
-export { buildSwapTx, toStellarAddress, toRawAmount } from './swap';
+export { buildSwapTx, toStellarAddress, toRawAmount, toXdrBase64 } from './swap';
 export type { PoolId, SwapTxParams, SwapUnsignedTx, StellarAddress, RawAmount, XdrBase64 } from './swap';

--- a/packages/sdk/src/swap.ts
+++ b/packages/sdk/src/swap.ts
@@ -27,12 +27,15 @@ export const toStellarAddress = (s: string): StellarAddress =>
 /** Cast a plain string to {@link RawAmount}. Use only at trust boundaries. */
 export const toRawAmount = (s: string): RawAmount => s as RawAmount;
 
+/** Cast a plain string to {@link XdrBase64}. Use only at trust boundaries. */
+export const toXdrBase64 = (s: string): XdrBase64 => s as XdrBase64;
+
 // ── Interfaces ────────────────────────────────────────────────────────────────
 
 /** Identifies a pool by its two token addresses. */
 export interface PoolId {
-  readonly token0: string;
-  readonly token1: string;
+  readonly token0: StellarAddress;
+  readonly token1: StellarAddress;
 }
 
 /**

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -45,141 +45,140 @@ class Spinner {
 export async function main() {
   const spinner = new Spinner();
 
-  // ── Tokens ────────────────────────────────────────────────────────────────
-  spinner.start('Seeding tokens…');
-  const token0Data: Prisma.TokenCreateInput = {
-    address: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
-    symbol: 'USDC',
-    name: 'USD Coin',
-    decimals: 6,
-    logoUri: 'https://example.com/usdc.png',
-  };
+  try {
+    // ── Tokens ──────────────────────────────────────────────────────────────
+    spinner.start('Seeding tokens…');
+    const token0Data: Prisma.TokenCreateInput = {
+      address: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      logoUri: 'https://example.com/usdc.png',
+    };
 
-  const token0 = await prisma.token.upsert({
-    where: { address: token0Data.address },
-    update: {},
-    create: token0Data,
-  });
+    const token0 = await prisma.token.upsert({
+      where: { address: token0Data.address },
+      update: {},
+      create: token0Data,
+    });
 
-  const token1Data: Prisma.TokenCreateInput = {
-    address: 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
-    symbol: 'XLM',
-    name: 'Stellar Lumens',
-    decimals: 7,
-    logoUri: 'https://example.com/xlm.png',
-  };
+    const token1Data: Prisma.TokenCreateInput = {
+      address: 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+      symbol: 'XLM',
+      name: 'Stellar Lumens',
+      decimals: 7,
+      logoUri: 'https://example.com/xlm.png',
+    };
 
-  const token1 = await prisma.token.upsert({
-    where: { address: token1Data.address },
-    update: {},
-    create: token1Data,
-  });
-  spinner.stop(true, `Tokens seeded  (${token0.symbol}, ${token1.symbol})`);
+    const token1 = await prisma.token.upsert({
+      where: { address: token1Data.address },
+      update: {},
+      create: token1Data,
+    });
+    spinner.stop(true, `Tokens seeded  (${token0.symbol}, ${token1.symbol})`);
 
-  // ── Pool ──────────────────────────────────────────────────────────────────
-  spinner.start('Seeding pool…');
-  const poolData: Prisma.PoolCreateInput = {
-    id: 'test-pool-1',
-    token0Address: token0.address,
-    token1Address: token1.address,
-    feeTier: 3000,
-    currentSqrtPrice: '79228162514264337593543950336',
-    currentTick: 0,
-    liquidity: '1000000000000000000',
-    tvl: '2000000000',
-    volume24h: '100000000',
-    feeApr: '0.05',
-  };
+    // ── Pool ────────────────────────────────────────────────────────────────
+    spinner.start('Seeding pool…');
+    const poolData: Prisma.PoolCreateInput = {
+      id: 'test-pool-1',
+      token0Address: token0.address,
+      token1Address: token1.address,
+      feeTier: 3000,
+      currentSqrtPrice: '79228162514264337593543950336',
+      currentTick: 0,
+      liquidity: '1000000000000000000',
+      tvl: '2000000000',
+      volume24h: '100000000',
+      feeApr: '0.05',
+    };
 
-  const pool = await prisma.pool.upsert({
-    where: { id: poolData.id },
-    update: {},
-    create: poolData,
-  });
-  spinner.stop(true, `Pool seeded    (${pool.id})`);
+    const pool = await prisma.pool.upsert({
+      where: { id: poolData.id },
+      update: {},
+      create: poolData,
+    });
+    spinner.stop(true, `Pool seeded    (${pool.id})`);
 
-  // ── Position ──────────────────────────────────────────────────────────────
-  spinner.start('Seeding position…');
-  const positionData: Prisma.PositionCreateInput = {
-    id: 'test-position-1',
-    poolId: pool.id,
-    ownerAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
-    tokenId: '1',
-    lowerTick: -60,
-    upperTick: 60,
-    liquidity: '1000000000000000000',
-    feesCollected0: '0',
-    feesCollected1: '0',
-  };
-
-  await prisma.position.upsert({
-    where: { id: positionData.id },
-    update: {},
-    create: positionData,
-  });
-  spinner.stop(true, 'Position seeded (test-position-1)');
-
-  // ── Swaps ─────────────────────────────────────────────────────────────────
-  spinner.start('Seeding swaps…');
-  const swapData: Prisma.SwapCreateManyInput[] = [
-    {
+    // ── Position ────────────────────────────────────────────────────────────
+    spinner.start('Seeding position…');
+    const positionData: Prisma.PositionCreateInput = {
+      id: 'test-position-1',
       poolId: pool.id,
-      senderAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
-      recipientAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
-      amount0: '1000000',
-      amount1: '0',
-      sqrtPriceAfter: '79228162514264337593543950336',
-      tickAfter: 0,
-      transactionHash: 'test-tx-1',
-    },
-    {
-      poolId: pool.id,
-      senderAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
-      recipientAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
-      amount0: '0',
-      amount1: '10000000',
-      sqrtPriceAfter: '79228162514264337593543950336',
-      tickAfter: 0,
-      transactionHash: 'test-tx-2',
-    },
-  ];
+      ownerAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+      tokenId: '1',
+      lowerTick: -60,
+      upperTick: 60,
+      liquidity: '1000000000000000000',
+      feesCollected0: '0',
+      feesCollected1: '0',
+    };
 
-  await prisma.swap.createMany({
-    data: swapData,
-  });
-  spinner.stop(true, 'Swaps seeded   (2 records)');
+    await prisma.position.upsert({
+      where: { id: positionData.id },
+      update: {},
+      create: positionData,
+    });
+    spinner.stop(true, 'Position seeded (test-position-1)');
 
-  // ── Price candles ─────────────────────────────────────────────────────────
-  spinner.start('Seeding price candles…');
-  const priceCandleData: Prisma.PriceCandleCreateManyInput[] = [
-    {
-      poolId: pool.id,
-      open: 1.0,
-      high: 1.05,
-      low: 0.95,
-      close: 1.02,
-      volumeUsd: 1000000.0,
-      periodStart: new Date(),
-      interval: '1h',
-    },
-  ];
+    // ── Swaps ────────────────────────────────────────────────────────────────
+    spinner.start('Seeding swaps…');
+    const swapData: Prisma.SwapCreateManyInput[] = [
+      {
+        poolId: pool.id,
+        senderAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        recipientAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        amount0: '1000000',
+        amount1: '0',
+        sqrtPriceAfter: '79228162514264337593543950336',
+        tickAfter: 0,
+        transactionHash: 'test-tx-1',
+      },
+      {
+        poolId: pool.id,
+        senderAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        recipientAddress: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        amount0: '0',
+        amount1: '10000000',
+        sqrtPriceAfter: '79228162514264337593543950336',
+        tickAfter: 0,
+        transactionHash: 'test-tx-2',
+      },
+    ];
 
-  await prisma.priceCandle.createMany({
-    data: priceCandleData,
-  });
-  spinner.stop(true, 'Price candles seeded (1 record)');
+    await prisma.swap.createMany({
+      data: swapData,
+    });
+    spinner.stop(true, 'Swaps seeded   (2 records)');
 
-  console.log('\nDatabase seeded successfully ✔');
+    // ── Price candles ────────────────────────────────────────────────────────
+    spinner.start('Seeding price candles…');
+    const priceCandleData: Prisma.PriceCandleCreateManyInput[] = [
+      {
+        poolId: pool.id,
+        open: 1.0,
+        high: 1.05,
+        low: 0.95,
+        close: 1.02,
+        volumeUsd: 1000000.0,
+        periodStart: new Date(),
+        interval: '1h',
+      },
+    ];
+
+    await prisma.priceCandle.createMany({
+      data: priceCandleData,
+    });
+    spinner.stop(true, 'Price candles seeded (1 record)');
+
+    console.log('\nDatabase seeded successfully ✔');
+  } finally {
+    await prisma.$disconnect();
+  }
 }
 
 if (require.main === module) {
-  main()
-    .then(async () => {
-      await prisma.$disconnect();
-    })
-    .catch(async (e) => {
-      console.error('\nSeed failed:', e);
-      await prisma.$disconnect();
-      process.exit(1);
-    });
+  main().catch((e) => {
+    console.error('\nSeed failed:', e);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
closes #217
closes #218 [api] Fix seed test coverage — runSeed() now explicitly calls main() instead of relying on the broken require.main guard. Move $disconnect() into main() with try/finally so it is always called and the disconnect assertion passes.

closes #219 [sdk] Improve TypeScript types in swap builder — PoolId.token0/1 now use the StellarAddress branded type; add toXdrBase64 cast helper and export it from the SDK index. Add swap.spec.ts with tests covering buildSwapTx output shape, payload encoding, and all cast helpers.

closes #227 [sdk] Tick-math loading-state tests already complete (no change). #217 [frontend] TokenSelector loading state already complete (no change).

## Summary
<!-- What does this PR do? -->

## Related issue
- Closes #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist
- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed