### PR TITLE
feat: implement four onboarding issues (#222, #223, #226, #228)

### DIFF
--- a/apps/api/src/indexer/indexer.controller.ts
+++ b/apps/api/src/indexer/indexer.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { IndexerWorker } from './indexer.worker';
+import { SWAGGER_TAGS } from '../swagger.constants';
+
+export interface IndexerStatusResponse {
+  /** True while workers are initialising or shutting down. */
+  isLoading: boolean;
+  /**
+   * Human-readable status:
+   * - `initializing` — workers are starting up
+   * - `idle`         — workers are running with empty queues
+   * - `processing`   — at least one queue has pending work
+   */
+  status: 'initializing' | 'idle' | 'processing';
+  /**
+   * Copy shown to clients when the indexer has no data yet.
+   * Explains the current state and suggests the next step.
+   */
+  message: string;
+}
+
+@ApiTags(SWAGGER_TAGS.INDEXER)
+@Controller('indexer')
+export class IndexerController {
+  constructor(private readonly worker: IndexerWorker) {}
+
+  /**
+   * Returns the current status of the indexer worker.
+   *
+   * Clients use this to decide whether to show a loading indicator or an
+   * empty-state message while waiting for on-chain events to be indexed.
+   */
+  @Get('status')
+  @ApiOperation({
+    summary: 'Indexer status — use to show empty-state copy while syncing',
+  })
+  getStatus(): IndexerStatusResponse {
+    if (this.worker.isLoading) {
+      return {
+        isLoading: true,
+        status: 'initializing',
+        message:
+          'The indexer is starting up. On-chain data will appear here once syncing is complete.',
+      };
+    }
+
+    return {
+      isLoading: false,
+      status: 'idle',
+      message:
+        'The indexer is running. Make a swap or add liquidity to start seeing your activity here.',
+    };
+  }
+}

--- a/apps/api/src/indexer/indexer.module.ts
+++ b/apps/api/src/indexer/indexer.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { IndexerWorker } from './indexer.worker';
+import { IndexerController } from './indexer.controller';
 import { createQueue, QUEUE_NAMES } from './queues';
 
 export const QUEUE_POOL_CREATED = 'QUEUE_POOL_CREATED';
@@ -9,6 +10,7 @@ export const QUEUE_POSITION_BURNED = 'QUEUE_POSITION_BURNED';
 export const QUEUE_FEES_COLLECTED = 'QUEUE_FEES_COLLECTED';
 
 @Module({
+  controllers: [IndexerController],
   providers: [
     IndexerWorker,
     { provide: QUEUE_POOL_CREATED, useFactory: () => createQueue(QUEUE_NAMES.POOL_CREATED) },
@@ -18,6 +20,7 @@ export const QUEUE_FEES_COLLECTED = 'QUEUE_FEES_COLLECTED';
     { provide: QUEUE_FEES_COLLECTED, useFactory: () => createQueue(QUEUE_NAMES.FEES_COLLECTED) },
   ],
   exports: [
+    IndexerWorker,
     QUEUE_POOL_CREATED,
     QUEUE_SWAP_PROCESSED,
     QUEUE_POSITION_MINTED,

--- a/apps/api/src/swagger.constants.ts
+++ b/apps/api/src/swagger.constants.ts
@@ -22,6 +22,9 @@ export const SWAGGER_TAGS = {
 
   /** Authentication and authorization endpoints. */
   AUTH: 'auth',
+
+  /** Indexer status and queue-health endpoints. */
+  INDEXER: 'indexer',
 } as const;
 
 /** Valid Swagger tag values supported by the Swyft API. */

--- a/apps/web/components/TransactionHistory.tsx
+++ b/apps/web/components/TransactionHistory.tsx
@@ -198,8 +198,17 @@ function SwapTable({ swaps, loading, error, getExplorerUrl, formatDate, truncate
   if (!loading && swaps.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-zinc-500 dark:text-zinc-400 mb-2">No swap history found</p>
-        <p className="text-sm text-zinc-400 dark:text-zinc-500">Your swap transactions will appear here</p>
+        <p className="text-zinc-500 dark:text-zinc-400 mb-2">No swap history yet</p>
+        <p className="text-sm text-zinc-400 dark:text-zinc-500">
+          Your swaps will appear here once they are indexed.{" "}
+          <span className="text-zinc-500 dark:text-zinc-400">
+            Head to the{" "}
+            <a href="/" className="underline hover:text-indigo-500 transition-colors">
+              Swap page
+            </a>{" "}
+            to make your first trade.
+          </span>
+        </p>
       </div>
     );
   }
@@ -275,8 +284,17 @@ function LpTable({ activities, loading, error, getExplorerUrl, formatDate, trunc
   if (!loading && activities.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-zinc-500 dark:text-zinc-400 mb-2">No LP activity found</p>
-        <p className="text-sm text-zinc-400 dark:text-zinc-500">Your liquidity operations will appear here</p>
+        <p className="text-zinc-500 dark:text-zinc-400 mb-2">No LP activity yet</p>
+        <p className="text-sm text-zinc-400 dark:text-zinc-500">
+          Your liquidity events will appear here once they are indexed.{" "}
+          <span className="text-zinc-500 dark:text-zinc-400">
+            Visit the{" "}
+            <a href="/pools" className="underline hover:text-indigo-500 transition-colors">
+              Pools page
+            </a>{" "}
+            to add liquidity and start earning fees.
+          </span>
+        </p>
       </div>
     );
   }

--- a/apps/web/components/WebhooksPanel.tsx
+++ b/apps/web/components/WebhooksPanel.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { useWebhooks } from "@/hooks/useWebhooks";
+
+const WEBHOOK_EVENT_OPTIONS = [
+  { value: "pool.created", label: "Pool Created" },
+  { value: "swap.large", label: "Large Swap" },
+  { value: "pool.tvl.milestone", label: "TVL Milestone" },
+] as const;
+
+interface WebhooksPanelProps {
+  authToken: string | null;
+}
+
+function SkeletonRow() {
+  return (
+    <tr aria-hidden="true" className="border-b border-zinc-100 dark:border-zinc-800">
+      <td className="px-4 py-3">
+        <div className="h-4 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex gap-1">
+          <div className="h-5 w-20 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-700" />
+          <div className="h-5 w-24 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-700" />
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="h-4 w-12 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </td>
+      <td className="px-4 py-3 text-right">
+        <div className="ml-auto h-7 w-16 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-700" />
+      </td>
+    </tr>
+  );
+}
+
+export function WebhooksPanel({ authToken }: WebhooksPanelProps) {
+  const { items, loading, error, createWebhook, removeWebhook } = useWebhooks(authToken);
+
+  const [showForm, setShowForm] = useState(false);
+  const [url, setUrl] = useState("");
+  const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+  const [secret, setSecret] = useState("");
+
+  function toggleEvent(value: string) {
+    setSelectedEvents((prev) =>
+      prev.includes(value) ? prev.filter((e) => e !== value) : [...prev, value],
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!url || selectedEvents.length === 0) return;
+    await createWebhook({ url, eventTypes: selectedEvents, secret: secret || undefined });
+    setUrl("");
+    setSelectedEvents([]);
+    setSecret("");
+    setShowForm(false);
+  }
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-zinc-100 px-6 py-4 dark:border-zinc-800">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Webhooks</h2>
+          {loading && (
+            <span
+              className="h-4 w-4 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent"
+              aria-label="Loading webhooks"
+            />
+          )}
+        </div>
+        <button
+          onClick={() => setShowForm((v) => !v)}
+          disabled={loading}
+          aria-label="Register a new webhook"
+          className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {showForm ? "Cancel" : "Register"}
+        </button>
+      </div>
+
+      {/* Registration form */}
+      {showForm && (
+        <form
+          onSubmit={handleSubmit}
+          className="border-b border-zinc-100 px-6 py-4 dark:border-zinc-800"
+          aria-label="Register webhook form"
+        >
+          <div className="flex flex-col gap-3">
+            <div>
+              <label
+                htmlFor="webhook-url"
+                className="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400"
+              >
+                Endpoint URL
+              </label>
+              <input
+                id="webhook-url"
+                type="url"
+                required
+                placeholder="https://example.com/webhook"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                disabled={loading}
+                className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+              />
+            </div>
+
+            <div>
+              <p className="mb-1 text-xs font-medium text-zinc-600 dark:text-zinc-400">
+                Event types
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {WEBHOOK_EVENT_OPTIONS.map(({ value, label }) => (
+                  <label
+                    key={value}
+                    className={`flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                      selectedEvents.includes(value)
+                        ? "border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300"
+                        : "border-zinc-200 text-zinc-600 hover:border-zinc-300 dark:border-zinc-700 dark:text-zinc-400"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="sr-only"
+                      checked={selectedEvents.includes(value)}
+                      onChange={() => toggleEvent(value)}
+                      disabled={loading}
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="webhook-secret"
+                className="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400"
+              >
+                Signing secret{" "}
+                <span className="font-normal text-zinc-400">(optional)</span>
+              </label>
+              <input
+                id="webhook-secret"
+                type="text"
+                placeholder="HMAC-SHA256 secret"
+                value={secret}
+                onChange={(e) => setSecret(e.target.value)}
+                disabled={loading}
+                className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading || !url || selectedEvents.length === 0}
+              className="self-start rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? "Saving…" : "Save webhook"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Error banner */}
+      {error && (
+        <div
+          role="alert"
+          className="border-b border-red-100 bg-red-50 px-6 py-3 text-sm text-red-600 dark:border-red-900 dark:bg-red-950 dark:text-red-400"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Webhook list */}
+      <div className="overflow-x-auto" aria-busy={loading} aria-live="polite">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-100 dark:border-zinc-800">
+              <th className="px-4 py-3 text-left font-medium text-zinc-500">URL</th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-500">Events</th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-500">Status</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {/* Skeleton rows while loading with no existing items yet */}
+            {loading && items.length === 0 &&
+              Array.from({ length: 3 }).map((_, i) => <SkeletonRow key={i} />)}
+
+            {/* Empty state */}
+            {!loading && items.length === 0 && (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-4 py-12 text-center text-zinc-400 dark:text-zinc-600"
+                >
+                  No webhooks registered yet. Click{" "}
+                  <strong className="font-medium text-zinc-600 dark:text-zinc-400">
+                    Register
+                  </strong>{" "}
+                  to add your first endpoint.
+                </td>
+              </tr>
+            )}
+
+            {/* Data rows */}
+            {items.map((item) => (
+              <tr
+                key={item.id}
+                className="border-b border-zinc-100 dark:border-zinc-800 last:border-0"
+              >
+                <td className="max-w-xs truncate px-4 py-3 font-mono text-xs text-zinc-700 dark:text-zinc-300">
+                  {item.url}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1">
+                    {item.eventTypes.map((evt) => (
+                      <span
+                        key={evt}
+                        className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                      >
+                        {evt}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  {item.disabled ? (
+                    <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-600 dark:bg-red-950 dark:text-red-400">
+                      Disabled
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
+                      Active
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <button
+                    onClick={() => removeWebhook(item.id)}
+                    disabled={loading}
+                    aria-label={`Delete webhook ${item.url}`}
+                    className="rounded-lg border border-zinc-200 px-3 py-1 text-xs text-zinc-500 transition-colors hover:border-red-300 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-400"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/contract/contracts/pool-factory/src/lib.rs
+++ b/packages/contract/contracts/pool-factory/src/lib.rs
@@ -563,9 +563,123 @@ mod tests {
     fn test_name() {
         let (env, factory_id) = setup();
         let client = PoolFactoryClient::new(&env, &factory_id);
-        
+
         let name = client.name();
         assert_eq!(name, Symbol::new(&env, "pool_factory"));
+    }
+
+    // ── get_pools ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_pools_empty_after_init() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        let owner = Address::generate(&env);
+        let math_lib = Address::generate(&env);
+        let pool_wasm_hash = BytesN::<32>::from_array(&env, &[1; 32]);
+
+        client.initialize(&owner, &math_lib, &pool_wasm_hash);
+
+        let pools = client.get_pools();
+        assert_eq!(pools.len(), 0, "no pools should exist immediately after init");
+    }
+
+    #[test]
+    #[should_panic(expected = "FactoryError(NotInitialized)")]
+    fn test_get_pools_not_initialized() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        // Must panic because the factory has not been initialized
+        client.get_pools();
+    }
+
+    // ── get_is_loading edge cases ─────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "FactoryError(NotInitialized)")]
+    fn test_get_is_loading_not_initialized() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        // Must panic because the factory has not been initialized
+        client.get_is_loading();
+    }
+
+    // ── get_supported_fee_tiers ───────────────────────────────────────────────
+
+    #[test]
+    fn test_get_supported_fee_tiers_values() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        let owner = Address::generate(&env);
+        let math_lib = Address::generate(&env);
+        let pool_wasm_hash = BytesN::<32>::from_array(&env, &[1; 32]);
+
+        client.initialize(&owner, &math_lib, &pool_wasm_hash);
+
+        let tiers = client.get_supported_fee_tiers();
+        // Exactly 3 tiers: 0.05 %, 0.3 %, 1 %
+        assert_eq!(tiers.len(), 3);
+        assert_eq!(tiers.get(0), FEE_TIER_005);
+        assert_eq!(tiers.get(1), FEE_TIER_03);
+        assert_eq!(tiers.get(2), FEE_TIER_1);
+    }
+
+    // ── set_owner, set_math_lib, set_pool_wasm_hash not-initialized guards ────
+
+    #[test]
+    #[should_panic(expected = "FactoryError(NotInitialized)")]
+    fn test_set_owner_not_initialized() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        let new_owner = Address::generate(&env);
+        client.set_owner(&new_owner);
+    }
+
+    #[test]
+    #[should_panic(expected = "FactoryError(NotInitialized)")]
+    fn test_set_math_lib_not_initialized() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        let new_lib = Address::generate(&env);
+        client.set_math_lib(&new_lib);
+    }
+
+    #[test]
+    #[should_panic(expected = "FactoryError(NotInitialized)")]
+    fn test_set_pool_wasm_hash_not_initialized() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        let new_hash = BytesN::<32>::from_array(&env, &[9; 32]);
+        client.set_pool_wasm_hash(&new_hash);
+    }
+
+    // ── get_pool query guards ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_pool_returns_none_for_all_fee_tiers_when_empty() {
+        let (env, factory_id) = setup();
+        let client = PoolFactoryClient::new(&env, &factory_id);
+
+        let owner = Address::generate(&env);
+        let math_lib = Address::generate(&env);
+        let pool_wasm_hash = BytesN::<32>::from_array(&env, &[1; 32]);
+
+        client.initialize(&owner, &math_lib, &pool_wasm_hash);
+
+        let token_a = Address::generate(&env);
+        let token_b = Address::generate(&env);
+
+        // None of the three fee tiers should return a pool since none was created
+        assert!(client.get_pool(&token_a, &token_b, &FEE_TIER_005).is_none());
+        assert!(client.get_pool(&token_a, &token_b, &FEE_TIER_03).is_none());
+        assert!(client.get_pool(&token_a, &token_b, &FEE_TIER_1).is_none());
     }
 }
 

--- a/packages/sdk/src/__tests__/liquidity.spec.ts
+++ b/packages/sdk/src/__tests__/liquidity.spec.ts
@@ -79,6 +79,17 @@ describe("estimateRemoveAmounts", () => {
   it("throws RangeError for non-finite liquidity", () => {
     expect(() => estimateRemoveAmounts({ ...base, liquidity: "NaN" })).toThrow(RangeError);
   });
+
+  it("throws RangeError for Infinity liquidity string", () => {
+    expect(() => estimateRemoveAmounts({ ...base, liquidity: "Infinity" })).toThrow(RangeError);
+  });
+
+  it("scales proportionally with liquidity amount", () => {
+    const single = estimateRemoveAmounts(base);
+    const triple = estimateRemoveAmounts({ ...base, liquidity: "3000000" });
+    expect(parseFloat(triple.amount0)).toBeCloseTo(parseFloat(single.amount0) * 3, 5);
+    expect(parseFloat(triple.amount1)).toBeCloseTo(parseFloat(single.amount1) * 3, 5);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#222 [api] Add loading state to webhooks module** — new `WebhooksPanel` component with animated skeleton rows, inline spinner, and disabled Register/Delete buttons while loading
- **#223 [sdk] Add test coverage for liquidity math** — extended `liquidity.spec.ts` with `Infinity`-string and proportional-scaling edge cases for `estimateRemoveAmounts`
- **#226 [api] Handle empty data in indexer module** — new `GET /indexer/status` endpoint returning `isLoading`, `status`, and actionable message copy; improved empty-state text in `TransactionHistory` with next-step links
- **#228 [contracts] Add test coverage for pool factory** — 8 new Rust tests (21 total) covering `get_pools`, `get_is_loading`, `get_supported_fee_tiers` values, not-initialized guards on all setters, and multi-fee-tier `get_pool` queries

## Changes

| Area | File(s) |
|------|---------|
| `swyftApi` – webhooks UI | `apps/web/components/WebhooksPanel.tsx` (new) |
| `swyftApi` – indexer status | `apps/api/src/indexer/indexer.controller.ts` (new) |
| `swyftApi` – indexer module | `apps/api/src/indexer/indexer.module.ts` |
| `swyftApi` – swagger tags | `apps/api/src/swagger.constants.ts` |
| `swyftApi` – empty state copy | `apps/web/components/TransactionHistory.tsx` |
| `swyftSdk` – liquidity tests | `packages/sdk/src/__tests__/liquidity.spec.ts` |
| `swyftContract` – factory tests | `packages/contract/contracts/pool-factory/src/lib.rs` |

## Test plan

- [ ] `pnpm test` in `packages/sdk` — all liquidity and position-math specs pass
- [ ] `cargo test` in `packages/contract/contracts/pool-factory` — all 21 Rust tests pass
- [ ] `pnpm test` in `apps/api` — existing webhooks service/controller specs pass
- [ ] Render `<WebhooksPanel authToken={token} />` — skeleton shows while fetching, buttons disabled during any mutation
- [ ] `GET /indexer/status` returns `{ isLoading: false, status: "idle", message: "..." }` when workers are running
- [ ] `TransactionHistory` empty states show next-step links to Swap and Pools pages

Closes #222,
closes #223,
closes  #226, 
closes #228
