### PR TITLE
  This PR addresses critical missing functionality in the Swyft API: registering an inactive module, fixing a database column reference bug

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { ApiKeysModule } from './api-keys/api-keys.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { CandlesModule } from './candles/candles.module';
 import { RateLimitModule } from './rate-limit/rate-limit.module';
+import { StatsModule } from './stats/stats.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { RateLimitModule } from './rate-limit/rate-limit.module';
     ApiKeysModule,
     WebhooksModule,
     CandlesModule,
+    StatsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/price/dto/candles-response.dto.ts
+++ b/apps/api/src/price/dto/candles-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PriceCandleDto } from './price-candle.dto';
+
+export class CandlesResponseDto {
+  @ApiProperty({
+    description: 'Array of candlestick data',
+    type: [PriceCandleDto],
+  })
+  data: PriceCandleDto[];
+}

--- a/apps/api/src/price/price.controller.ts
+++ b/apps/api/src/price/price.controller.ts
@@ -16,6 +16,7 @@ import {
 import { PriceService, SpotPriceResponse } from './price.service';
 import { CacheService, TTL } from '../cache/cache.service';
 import { PriceCandleDto } from './dto/price-candle.dto';
+import { CandlesResponseDto } from './dto/candles-response.dto';
 import { SWAGGER_TAGS } from '../swagger.constants';
 
 const VALID_INTERVALS = ['1m', '5m', '1h', '1d'] as const;
@@ -80,7 +81,7 @@ export class PriceController {
   })
   @ApiResponse({
     status: 200,
-    type: [PriceCandleDto],
+    type: CandlesResponseDto,
     description: 'Candlestick data retrieved successfully',
   })
   @ApiResponse({ status: 400, description: 'Invalid parameters' })
@@ -95,7 +96,7 @@ export class PriceController {
     @Query('from') from?: string,
     @Query('to') to?: string,
     @Query('limit') limit?: string,
-  ): Promise<PriceCandleDto[]> {
+  ): Promise<CandlesResponseDto> {
     if (!VALID_INTERVALS.includes(interval)) {
       throw new BadRequestException(
         `Invalid interval. Must be one of: ${VALID_INTERVALS.join(', ')}`,
@@ -151,9 +152,10 @@ export class PriceController {
       interval === '1m' || interval === '5m'
         ? TTL.CANDLES_FAST
         : TTL.CANDLES_SLOW;
-    await this.cacheService.set(cacheKey, candles, ttl);
+    const response: CandlesResponseDto = { data: candles };
+    await this.cacheService.set(cacheKey, response, ttl);
 
-    return candles;
+    return response;
   }
 
   private getDefaultIntervalSeconds(interval: CandleInterval): number {

--- a/apps/api/src/price/price.service.spec.ts
+++ b/apps/api/src/price/price.service.spec.ts
@@ -6,6 +6,7 @@ import {
   spotPriceCacheKey,
 } from './price.service';
 import { CacheService } from '../cache/cache.service';
+import { PrismaService } from '../prisma/prisma.service';
 import Redis from 'ioredis';
 import { WebSocket } from 'ws';
 
@@ -38,6 +39,7 @@ let mockSub: ReturnType<typeof buildMockSubscriber>;
 describe('PriceService', () => {
   let service: PriceService;
   let mockCache: jest.Mocked<Pick<CacheService, 'get' | 'set' | 'invalidate'>>;
+  let mockPrisma: jest.Mocked<PrismaService>;
 
   beforeEach(() => {
     mockSub = buildMockSubscriber();
@@ -47,7 +49,11 @@ describe('PriceService', () => {
       invalidate: jest.fn().mockResolvedValue(undefined),
       createSubscriber: jest.fn().mockReturnValue(mockSub),
     } as unknown as CacheService;
-    service = new PriceService(mockCache);
+    mockPrisma = {
+      pool: { findFirst: jest.fn() },
+      priceCandle: { findMany: jest.fn() },
+    } as unknown as jest.Mocked<PrismaService>;
+    service = new PriceService(mockCache, mockPrisma);
     service.onModuleInit();
   });
 
@@ -216,6 +222,55 @@ describe('PriceService', () => {
       for (const c of clients) {
         expect(c.send as jest.Mock).toHaveBeenCalledTimes(1);
       }
+    });
+  });
+
+  describe('getCandles', () => {
+    it('returns empty array when no pool is found', async () => {
+      mockPrisma.pool.findFirst.mockResolvedValueOnce(null);
+      const result = await service.getCandles('USDC', 'XLM', '1h', 100, 200, 10);
+      expect(result).toEqual([]);
+    });
+
+    it('queries price_candle table for found pool', async () => {
+      const mockPool = { id: 'pool-1' };
+      const mockCandles = [
+        {
+          id: 'candle-1',
+          poolId: 'pool-1',
+          interval: '1h',
+          open: 100,
+          high: 105,
+          low: 95,
+          close: 102,
+          volumeUsd: 10000,
+          periodStart: new Date(100000),
+          pool: null,
+        },
+      ];
+      mockPrisma.pool.findFirst.mockResolvedValueOnce(mockPool as never);
+      mockPrisma.priceCandle.findMany.mockResolvedValueOnce(mockCandles as never);
+
+      const result = await service.getCandles('USDC', 'XLM', '1h', 100, 200, 10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].open).toBe('100');
+      expect(result[0].high).toBe('105');
+      expect(result[0].low).toBe('95');
+      expect(result[0].close).toBe('102');
+      expect(result[0].volume).toBe('10000');
+      expect(mockPrisma.priceCandle.findMany).toHaveBeenCalledWith({
+        where: {
+          poolId: 'pool-1',
+          interval: '1h',
+          periodStart: {
+            gte: new Date(100000),
+            lte: new Date(200000),
+          },
+        },
+        orderBy: { periodStart: 'asc' },
+        take: 10,
+      });
     });
   });
 });

--- a/apps/api/src/price/price.service.ts
+++ b/apps/api/src/price/price.service.ts
@@ -8,6 +8,7 @@ import {
 import Redis from 'ioredis';
 import { WebSocket } from 'ws';
 import { CacheService, TTL } from '../cache/cache.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 export interface PriceEvent {
   poolId: string;
@@ -60,7 +61,10 @@ export class PriceService implements OnModuleInit, OnModuleDestroy {
   /** client → poolIds it subscribed to */
   private clientPools = new Map<WebSocket, Set<string>>();
 
-  constructor(private readonly cache: CacheService) {}
+  constructor(
+    private readonly cache: CacheService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   onModuleInit() {
     this.subscriber = this.cache.createSubscriber();
@@ -183,35 +187,52 @@ export class PriceService implements OnModuleInit, OnModuleDestroy {
     to: number,
     limit: number,
   ): Promise<PriceCandle[]> {
-    // Mock implementation - in production this would query the PriceCandle table
-    const candles: PriceCandle[] = [];
-    const intervalSeconds = this.getIntervalSeconds(interval);
+    const tokenALower = tokenA.toLowerCase();
+    const tokenBLower = tokenB.toLowerCase();
 
-    for (let i = 0; i < limit; i++) {
-      const timestamp = from + i * intervalSeconds;
-      if (timestamp > to) break;
+    const pool = await this.prisma.pool.findFirst({
+      where: {
+        OR: [
+          {
+            token0Address: { equals: tokenALower, mode: 'insensitive' },
+            token1Address: { equals: tokenBLower, mode: 'insensitive' },
+          },
+          {
+            token0Address: { equals: tokenBLower, mode: 'insensitive' },
+            token1Address: { equals: tokenALower, mode: 'insensitive' },
+          },
+        ],
+      },
+    });
 
-      // Generate realistic-looking candle data
-      const basePrice = 2000 + Math.random() * 100;
-      const volatility = 0.02; // 2% volatility
-
-      candles.push({
-        timestamp,
-        open: (
-          basePrice +
-          (Math.random() - 0.5) * basePrice * volatility
-        ).toFixed(2),
-        high: (basePrice + Math.random() * basePrice * volatility).toFixed(2),
-        low: (basePrice - Math.random() * basePrice * volatility).toFixed(2),
-        close: (
-          basePrice +
-          (Math.random() - 0.5) * basePrice * volatility
-        ).toFixed(2),
-        volume: (Math.random() * 1000000).toFixed(2),
-      });
+    if (!pool) {
+      return [];
     }
 
-    return candles;
+    const fromDate = new Date(from * 1000);
+    const toDate = new Date(to * 1000);
+
+    const priceCandles = await this.prisma.priceCandle.findMany({
+      where: {
+        poolId: pool.id,
+        interval,
+        periodStart: {
+          gte: fromDate,
+          lte: toDate,
+        },
+      },
+      orderBy: { periodStart: 'asc' },
+      take: limit,
+    });
+
+    return priceCandles.map((candle) => ({
+      timestamp: Math.floor(candle.periodStart.getTime() / 1000),
+      open: candle.open.toString(),
+      high: candle.high.toString(),
+      low: candle.low.toString(),
+      close: candle.close.toString(),
+      volume: candle.volumeUsd.toString(),
+    }));
   }
 
   private getIntervalSeconds(interval: string): number {

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -94,8 +94,8 @@ export class SearchService {
           token_b."symbol" AS "tokenBSymbol",
           p."fee"
         FROM "pool_created" p
-        LEFT JOIN "token" token_a ON lower(token_a."contractAddress") = lower(p."tokenA")
-        LEFT JOIN "token" token_b ON lower(token_b."contractAddress") = lower(p."tokenB")
+        LEFT JOIN "token" token_a ON lower(token_a."address") = lower(p."tokenA")
+        LEFT JOIN "token" token_b ON lower(token_b."address") = lower(p."tokenB")
         WHERE
           lower(p."poolId") = lower($1)
           OR token_a."symbol" ILIKE $2


### PR DESCRIPTION
 ## Summary                                                                                                                                      
                                                                                                                                                  
  This PR addresses critical missing functionality in the Swyft API: registering an inactive module, fixing a database column reference bug,
  wiring the candles endpoint to the price_candle table, and returning the expected response shape for frontend consumption.                      
                                                                                                                                                  
  ## Changes                                         
                                                                                                                                                  
  ### #337 — Register StatsModule in AppModule                                                                                                  
  - Added `StatsModule` import statement                                                                                                          
  - Registered `StatsModule` in the `imports` array alongside other modules
  - Enables StatsWorker and StatsScheduler to load and run                                                                                        
                                                                                                                                                
  ### #338 — Fix search SQL contractAddress column       
  - Corrected LEFT JOIN conditions in `searchPools` query from `token_a."contractAddress"` and `token_b."contractAddress"` to `token_a."address"`
  and `token_b."address"`                                                                                                                         
  - The token table schema uses `address` as the column name, not `contractAddress`
  - This fix allows pool searches to correctly join token symbols to their addresses                                                              
                                                                                                                                                  
  ### #339 — Wire getCandles to price_candle table                                                                                                
  - Injected `PrismaService` into `PriceService`                                                                                                  
  - Replaced mock candle generation with real database queries                                                                                    
  - Implemented token pair to pool lookup (case-insensitive, handles both token orderings)
  - Queries `price_candle` table with filters for poolId, interval, and periodStart range                                                         
  - Returns empty array when no pool exists (no error thrown)                                                                                     
  - Added unit tests verifying pool lookups and candle retrieval                                                                                  
  - Updated test mocks to support new Prisma dependency                                                                                           
                                                                                                                                                  
  ### #340 — Return candles wrapper shape for frontend                                                                                            
  - Created `CandlesResponseDto` with `data: PriceCandleDto[]` wrapper structure                                                                  
  - Updated `PriceController.getCandles()` return type and Swagger response type                                                                  
  - Wrapped candle arrays in the `{ data: [...] }` shape before returning                                                                         
  - Updated caching to cache the wrapped response                                                                                                 
                                                                                                                                                  
  ## Testing                                                                                                                                    
                                                                                                                                                  
  All existing tests pass after the changes:                                                                                                      
  npm test                                                                                                                                        
                                                                                                                                                  
  The following were verified:                                                                                                                    
  - **#337**: StatsModule is now imported and can be instantiated by NestJS                                                                       
  - **#338**: Search queries no longer fail with column name errors                                                                               
  - **#339**: `getCandles` returns real data from the `price_candle` table (verified via unit tests with mocked Prisma)                           
  - **#340**: Candles response is wrapped in `{ data: [...] }` shape matching frontend expectations
                                                                                                                                                  
  ## Notes                                                                                                                                      
                                                         
  - The token pair lookup in #339 matches pools where token0Address and token1Address contain the provided tokens in either order                 
  (case-insensitive)                                                                                                                              
  - The response wrapper in #340 follows the `{ data: array }` pattern seen in similar list endpoints                                             
  - All timestamps in candles are converted from JavaScript milliseconds to Unix seconds                                                          
  - Column names confirmed from Prisma schema definitions                                                                                         
  - No schema migrations were required; all fixes use existing columns                                                                          
                                                                                                                                                  
  Closes #337, Closes #338, Closes #339, Closes #340  