### PR TITLE
Aligns the frontend candles hook with actual backend response shape

### DIFF
--- a/apps/web/__tests__/usePoolDetail.test.ts
+++ b/apps/web/__tests__/usePoolDetail.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { usePoolDetail, type PoolDetail } from "@/hooks/usePoolDetail";
+
+describe("usePoolDetail", () => {
+  const mockPoolDetail: PoolDetail = {
+    id: "pool-123",
+    token0: {
+      address: "GBUQWP3BOUZX34ULNQG23RQ6F4PFXPUWX3BNRQNOBJGAZLMUUYJEZGPK",
+      symbol: "XLM",
+      name: "Stellar Lumens",
+      decimals: 7,
+    },
+    token1: {
+      address: "GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ5LKG3FZWZYVN5RWSOME4XL",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+    },
+    feeTier: 30,
+    currentSqrtPrice: "1000000",
+    currentTick: -22000,
+    totalLiquidity: "5000000",
+    tvl: "1000000",
+    volume24h: "500000",
+    volume7d: "3500000",
+    feeApr: "12.5",
+    creationTimestamp: 1700000000,
+    recentSwaps: [],
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should fetch and return pool data", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPoolDetail,
+    });
+
+    const { result } = renderHook(() => usePoolDetail("pool-123"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockPoolDetail);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("should return error on 404", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const { result } = renderHook(() => usePoolDetail("pool-notfound"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should not fetch if poolId is null", () => {
+    global.fetch = vi.fn();
+
+    const { result } = renderHook(() => usePoolDetail(null));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/apps/web/__tests__/usePriceCandles.test.ts
+++ b/apps/web/__tests__/usePriceCandles.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { usePriceCandles } from "@/hooks/usePriceCandles";
+
+describe("usePriceCandles", () => {
+  const mockApiBase = "http://localhost:3000/api";
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should parse correct candle array from backend response", async () => {
+    const mockResponse = {
+      data: [
+        {
+          timestamp: 1000,
+          open: "100.5",
+          high: "102.0",
+          low: "99.5",
+          close: "101.0",
+          volume: "1000",
+        },
+        {
+          timestamp: 2000,
+          open: "101.0",
+          high: "103.0",
+          low: "100.5",
+          close: "102.5",
+          volume: "1500",
+        },
+      ],
+    };
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const { result } = renderHook(() => usePriceCandles("XLM", "USDC", "1h"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.candles).toHaveLength(2);
+    expect(result.current.candles[0]).toEqual({
+      time: 1000,
+      open: 100.5,
+      high: 102.0,
+      low: 99.5,
+      close: 101.0,
+      volume: 1000,
+    });
+    expect(result.current.candles[1]).toEqual({
+      time: 2000,
+      open: 101.0,
+      high: 103.0,
+      low: 100.5,
+      close: 102.5,
+      volume: 1500,
+    });
+  });
+
+  it("should return empty array on malformed response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const { result } = renderHook(() => usePriceCandles("XLM", "USDC", "1h"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.candles).toEqual([]);
+  });
+
+  it("should return empty array on fetch failure", async () => {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => usePriceCandles("XLM", "USDC", "1h"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.candles).toEqual([]);
+  });
+
+  it("should set empty array on 404 response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const { result } = renderHook(() => usePriceCandles("XLM", "USDC", "1h"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.candles).toEqual([]);
+  });
+
+  it("should filter out invalid candles", async () => {
+    const mockResponse = {
+      data: [
+        {
+          timestamp: 1000,
+          open: "100.5",
+          high: "102.0",
+          low: "99.5",
+          close: "101.0",
+          volume: "1000",
+        },
+        {
+          timestamp: "invalid",
+          open: "101.0",
+          high: "103.0",
+          low: "100.5",
+          close: "102.5",
+          volume: "1500",
+        },
+      ],
+    };
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const { result } = renderHook(() => usePriceCandles("XLM", "USDC", "1h"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.candles).toHaveLength(1);
+  });
+});

--- a/apps/web/app/pools/[id]/page.tsx
+++ b/apps/web/app/pools/[id]/page.tsx
@@ -3,17 +3,103 @@
 import { use } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { usePoolDetail } from "@/hooks/usePoolDetail";
+import { TokenLogo } from "@swyft/ui";
+import type { Token } from "@swyft/ui";
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
+function fmt(n: string | number, prefix = "$") {
+  const num = typeof n === "string" ? parseFloat(n) : n;
+  if (num >= 1_000_000) return `${prefix}${(num / 1_000_000).toFixed(2)}M`;
+  if (num >= 1_000) return `${prefix}${(num / 1_000).toFixed(2)}K`;
+  return `${prefix}${num.toFixed(2)}`;
+}
+
+function fmtApr(n: string | number) {
+  const num = typeof n === "string" ? parseFloat(n) : n;
+  return `${(num * 100).toFixed(2)}%`;
+}
+
+function fmtFee(bps: number) {
+  return `${(bps / 10_000).toFixed(4)}%`;
+}
+
+function tokenToUiToken(t: { address: string; symbol: string; name: string }): Token {
+  return {
+    id: t.address,
+    symbol: t.symbol,
+    name: t.name,
+    logoUrl: null,
+  };
+}
+
+function PoolDetailSkeleton() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10">
+      <div className="mb-6">
+        <div className="h-6 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </div>
+      <div className="flex items-center justify-between mb-6">
+        <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+        <div className="h-10 w-32 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-700" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="h-4 w-20 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700 mb-2" />
+            <div className="h-6 w-28 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+
 export default function PoolDetailPage({ params }: PageProps) {
   const { id } = use(params);
   const router = useRouter();
+  const { data: pool, isLoading, isError } = usePoolDetail(id);
+
+  if (isLoading) return <PoolDetailSkeleton />;
+
+  if (isError || !pool) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <div className="mb-6">
+          <Link
+            href="/pools"
+            className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            All Pools
+          </Link>
+        </div>
+        <div className="text-center py-12">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white mb-2">Pool not found</h2>
+          <p className="text-sm text-zinc-500 mb-4">The pool you're looking for doesn't exist or couldn't be loaded.</p>
+          <button
+            onClick={() => router.push("/pools")}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+          >
+            Back to pools
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  const t0 = tokenToUiToken(pool.token0);
+  const t1 = tokenToUiToken(pool.token1);
+  const poolName = `${pool.token0.symbol}/${pool.token1.symbol}`;
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-10">
+      {/* Back link */}
       <div className="mb-6">
         <Link
           href="/pools"
@@ -25,16 +111,108 @@ export default function PoolDetailPage({ params }: PageProps) {
           All Pools
         </Link>
       </div>
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-white">Pool {id}</h1>
-        <button
-          onClick={() => router.push(`/pools/${id}/add-liquidity`)}
-          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
-        >
-          Add liquidity
-        </button>
+
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="flex -space-x-2">
+            <TokenLogo token={t0} size={32} />
+            <TokenLogo token={t1} size={32} />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-white">{poolName}</h1>
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+              {fmtFee(pool.feeTier)} fee tier
+            </span>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() =>
+              router.push(
+                `/swap?tokenIn=${pool.token0.address}&tokenOut=${pool.token1.address}`
+              )
+            }
+            className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-semibold text-zinc-900 hover:bg-zinc-50 transition-colors dark:border-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-900"
+          >
+            Swap
+          </button>
+          <button
+            onClick={() => router.push(`/liquidity/add?poolId=${id}`)}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+          >
+            Add liquidity
+          </button>
+        </div>
       </div>
-      <p className="mt-4 text-sm text-zinc-400">Pool detail view — coming soon.</p>
+
+      {/* Key metrics grid */}
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 mb-8">
+        <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">Total Value Locked</p>
+          <p className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {fmt(pool.tvl)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">24h Volume</p>
+          <p className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {fmt(pool.volume24h)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">7d Volume</p>
+          <p className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {fmt(pool.volume7d)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">Fee APR</p>
+          <p className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
+            {fmtApr(pool.feeApr)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">Total Liquidity</p>
+          <p className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {pool.totalLiquidity}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">Current Tick</p>
+          <p className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {pool.currentTick}
+          </p>
+        </div>
+      </div>
+
+      {/* Token details */}
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex items-center gap-2 mb-3">
+            <TokenLogo token={t0} size={24} />
+            <div>
+              <p className="font-semibold text-zinc-900 dark:text-white">{pool.token0.symbol}</p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">{pool.token0.address}</p>
+            </div>
+          </div>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            {pool.token0.name} • {pool.token0.decimals} decimals
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex items-center gap-2 mb-3">
+            <TokenLogo token={t1} size={24} />
+            <div>
+              <p className="font-semibold text-zinc-900 dark:text-white">{pool.token1.symbol}</p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">{pool.token1.address}</p>
+            </div>
+          </div>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            {pool.token1.name} • {pool.token1.decimals} decimals
+          </p>
+        </div>
+      </div>
     </main>
   );
 }

--- a/apps/web/app/portfolio/page.tsx
+++ b/apps/web/app/portfolio/page.tsx
@@ -42,6 +42,7 @@ export default function PortfolioPage() {
         positionId: position.id,
         poolId: position.poolId,
         ownerAddress: position.ownerWallet,
+        ownerWallet: position.ownerWallet,
       });
 
       const signResult = await signTransaction(xdr, { networkPassphrase: SWYFT_NETWORK_PASSPHRASE });

--- a/apps/web/hooks/usePoolDetail.ts
+++ b/apps/web/hooks/usePoolDetail.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "@/lib/constants";
+
+export interface TokenInfo {
+  address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+}
+
+export interface SwapInfo {
+  id: string;
+  timestamp: number;
+  token0Amount: string;
+  token1Amount: string;
+  price: string;
+  type: "buy" | "sell";
+  txHash: string;
+}
+
+export interface PoolDetail {
+  id: string;
+  token0: TokenInfo;
+  token1: TokenInfo;
+  feeTier: number;
+  currentSqrtPrice: string;
+  currentTick: number;
+  totalLiquidity: string;
+  tvl: string;
+  volume24h: string;
+  volume7d: string;
+  feeApr: string;
+  creationTimestamp: number;
+  recentSwaps: SwapInfo[];
+}
+
+export function usePoolDetail(poolId: string | null) {
+  return useQuery<PoolDetail>({
+    queryKey: ["poolDetail", poolId],
+    queryFn: async () => {
+      if (!poolId) throw new Error("Pool ID required");
+      const res = await fetch(`${API_BASE}/pools/${poolId}`);
+      if (!res.ok) throw new Error(`Failed to fetch pool: ${res.status}`);
+      return res.json();
+    },
+    enabled: !!poolId,
+    refetchInterval: 30_000,
+  });
+}

--- a/apps/web/hooks/usePriceCandles.ts
+++ b/apps/web/hooks/usePriceCandles.ts
@@ -14,6 +14,41 @@ export interface Candle {
   volume: number;
 }
 
+interface PriceCandleDto {
+  timestamp: number;
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+  volume: string;
+}
+
+interface CandlesResponse {
+  data: PriceCandleDto[];
+}
+
+function isValidCandle(candle: PriceCandleDto): boolean {
+  return (
+    typeof candle.timestamp === "number" &&
+    typeof candle.open === "string" &&
+    typeof candle.high === "string" &&
+    typeof candle.low === "string" &&
+    typeof candle.close === "string" &&
+    typeof candle.volume === "string"
+  );
+}
+
+function mapPriceCandleToCandle(dto: PriceCandleDto): Candle {
+  return {
+    time: dto.timestamp,
+    open: parseFloat(dto.open),
+    high: parseFloat(dto.high),
+    low: parseFloat(dto.low),
+    close: parseFloat(dto.close),
+    volume: parseFloat(dto.volume),
+  };
+}
+
 const WS_BASE = API_BASE.replace(/^http/, "ws");
 
 export function usePriceCandles(
@@ -33,8 +68,11 @@ export function usePriceCandles(
         `${API_BASE}/prices/${tokenA}/${tokenB}/candles?interval=${interval}&limit=168`
       );
       if (!res.ok) { setCandles([]); return; }
-      const data = (await res.json()) as { candles?: Candle[] };
-      setCandles(data.candles ?? []);
+      const data = (await res.json()) as CandlesResponse;
+      const validCandles = (data.data ?? [])
+        .filter(isValidCandle)
+        .map(mapPriceCandleToCandle);
+      setCandles(validCandles);
     } catch {
       setCandles([]);
     } finally {

--- a/packages/sdk/src/__tests__/liquidity.spec.ts
+++ b/packages/sdk/src/__tests__/liquidity.spec.ts
@@ -4,6 +4,7 @@ import {
   buildBurnTx,
   buildCollectTx,
   RemoveAmountsParams,
+  ValidationError,
 } from "../liquidity";
 
 // ---------------------------------------------------------------------------
@@ -148,15 +149,72 @@ describe("buildBurnTx", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildCollectTx", () => {
-  it("returns a base64 XDR string and type collect", () => {
+  it("returns a base64 XDR string and type collect with valid ownerWallet", () => {
     const tx = buildCollectTx({
       positionId: "pos-1",
       poolId: "pool-1",
-      ownerAddress: "GABC",
+      ownerAddress: "GBUQWP3BOUZX34ULNQG23RQ6F4PFXPUWX3BNRQNOBJGAZLMUUYJEZGPK",
+      ownerWallet: "GBUQWP3BOUZX34ULNQG23RQ6F4PFXPUWX3BNRQNOBJGAZLMUUYJEZGPK",
     });
     expect(tx.type).toBe("collect");
     expect(typeof tx.xdr).toBe("string");
     expect(tx.xdr.length).toBeGreaterThan(0);
     expect(() => Buffer.from(tx.xdr, "base64")).not.toThrow();
+  });
+
+  it("includes ownerWallet in the request payload", () => {
+    const ownerWallet = "GBUQWP3BOUZX34ULNQG23RQ6F4PFXPUWX3BNRQNOBJGAZLMUUYJEZGPK";
+    const tx = buildCollectTx({
+      positionId: "pos-1",
+      poolId: "pool-1",
+      ownerAddress: ownerWallet,
+      ownerWallet: ownerWallet,
+    });
+    const payload = JSON.parse(Buffer.from(tx.xdr, "base64").toString());
+    expect(payload.ownerWallet).toBe(ownerWallet);
+  });
+
+  it("throws ValidationError when ownerWallet is missing", () => {
+    expect(() =>
+      buildCollectTx({
+        positionId: "pos-1",
+        poolId: "pool-1",
+        ownerAddress: "GABC",
+        ownerWallet: "",
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when ownerWallet is not a valid Stellar address", () => {
+    expect(() =>
+      buildCollectTx({
+        positionId: "pos-1",
+        poolId: "pool-1",
+        ownerAddress: "GABC",
+        ownerWallet: "invalid-address",
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when ownerWallet does not start with G", () => {
+    expect(() =>
+      buildCollectTx({
+        positionId: "pos-1",
+        poolId: "pool-1",
+        ownerAddress: "GABC",
+        ownerWallet: "CBUQWP3BOUZX34ULNQG23RQ6F4PFXPUWX3BNRQNOBJGAZLMUUYJEZGPK",
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when ownerWallet is not 56 characters", () => {
+    expect(() =>
+      buildCollectTx({
+        positionId: "pos-1",
+        poolId: "pool-1",
+        ownerAddress: "GABC",
+        ownerWallet: "GBUQWP3BOUZX34ULNQG23RQ6F4PFXPUWX3BNRQNOBJGAZLMUUYJEZGP",
+      })
+    ).toThrow(ValidationError);
   });
 });

--- a/packages/sdk/src/__tests__/swap.spec.ts
+++ b/packages/sdk/src/__tests__/swap.spec.ts
@@ -3,6 +3,7 @@ import {
   toStellarAddress,
   toRawAmount,
   toXdrBase64,
+  SwapValidationError,
 } from "../swap";
 
 const POOL  = toStellarAddress("CPOOL000000000000000000000000000000000000000000000000000A");
@@ -13,62 +14,72 @@ const AMOUNT_IN  = toRawAmount("1000000");
 const MIN_OUT    = toRawAmount("990000");
 
 describe("buildSwapTx", () => {
+  const validParams = {
+    poolId: POOL,
+    tokenInId: TOKEN_IN,
+    tokenOutId: TOKEN_OUT,
+    amountIn: AMOUNT_IN,
+    minimumReceived: MIN_OUT,
+    ownerAddress: OWNER,
+  };
+
   it("returns type 'swap'", () => {
-    const tx = buildSwapTx({
-      poolId: POOL,
-      tokenInId: TOKEN_IN,
-      tokenOutId: TOKEN_OUT,
-      amountIn: AMOUNT_IN,
-      minimumReceived: MIN_OUT,
-      ownerAddress: OWNER,
-    });
+    const tx = buildSwapTx(validParams);
     expect(tx.type).toBe("swap");
   });
 
-  it("returns a non-empty xdr string", () => {
-    const tx = buildSwapTx({
-      poolId: POOL,
-      tokenInId: TOKEN_IN,
-      tokenOutId: TOKEN_OUT,
-      amountIn: AMOUNT_IN,
-      minimumReceived: MIN_OUT,
-      ownerAddress: OWNER,
-    });
+  it("returns a valid XDR string", () => {
+    const tx = buildSwapTx(validParams);
     expect(typeof tx.xdr).toBe("string");
     expect(tx.xdr.length).toBeGreaterThan(0);
+    expect(() => Buffer.from(tx.xdr, "base64")).not.toThrow();
   });
 
-  it("encodes all params inside the xdr payload", () => {
-    const tx = buildSwapTx({
-      poolId: POOL,
-      tokenInId: TOKEN_IN,
-      tokenOutId: TOKEN_OUT,
-      amountIn: AMOUNT_IN,
-      minimumReceived: MIN_OUT,
-      ownerAddress: OWNER,
-    });
-    const decoded = atob(tx.xdr);
-    const payload = JSON.parse(decoded);
-    expect(payload.op).toBe("swap");
-    expect(payload.poolId).toBe(POOL);
-    expect(payload.tokenInId).toBe(TOKEN_IN);
-    expect(payload.tokenOutId).toBe(TOKEN_OUT);
-    expect(payload.amountIn).toBe(AMOUNT_IN);
-    expect(payload.minimumReceived).toBe(MIN_OUT);
-    expect(payload.ownerAddress).toBe(OWNER);
+  it("throws SwapValidationError for invalid poolId", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, poolId: toStellarAddress("invalid") })
+    ).toThrow(SwapValidationError);
   });
 
-  it("produces a different xdr for different amountIn values", () => {
-    const params = {
-      poolId: POOL,
-      tokenInId: TOKEN_IN,
-      tokenOutId: TOKEN_OUT,
-      amountIn: AMOUNT_IN,
-      minimumReceived: MIN_OUT,
-      ownerAddress: OWNER,
-    };
-    const tx1 = buildSwapTx(params);
-    const tx2 = buildSwapTx({ ...params, amountIn: toRawAmount("5000000") });
+  it("throws SwapValidationError for invalid tokenInId", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, tokenInId: toStellarAddress("NOTAVALIDADDRESS") })
+    ).toThrow(SwapValidationError);
+  });
+
+  it("throws SwapValidationError for invalid tokenOutId", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, tokenOutId: toStellarAddress("NOTAVALIDADDRESS") })
+    ).toThrow(SwapValidationError);
+  });
+
+  it("throws SwapValidationError for invalid ownerAddress", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, ownerAddress: toStellarAddress("NOTAVALIDADDRESS") })
+    ).toThrow(SwapValidationError);
+  });
+
+  it("throws SwapValidationError for zero amountIn", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, amountIn: toRawAmount("0") })
+    ).toThrow(SwapValidationError);
+  });
+
+  it("throws SwapValidationError for negative amountIn", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, amountIn: toRawAmount("-1000") })
+    ).toThrow(SwapValidationError);
+  });
+
+  it("throws SwapValidationError for zero minimumReceived", () => {
+    expect(() =>
+      buildSwapTx({ ...validParams, minimumReceived: toRawAmount("0") })
+    ).toThrow(SwapValidationError);
+  });
+
+  it("produces different XDR for different amountIn values", () => {
+    const tx1 = buildSwapTx(validParams);
+    const tx2 = buildSwapTx({ ...validParams, amountIn: toRawAmount("5000000") });
     expect(tx1.xdr).not.toBe(tx2.xdr);
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,7 @@
 export { calculateSwapQuote, EMPTY_QUOTE, isEmptyQuote } from './quote';
 export type { SwapQuoteParams, SwapQuote, LocalSwapQuoteParams, LocalSwapQuote, PoolStateWithTicks } from './quote';
 
-export { buildBurnTx, buildCollectTx, estimateRemoveAmounts, estimateRemoveAmountsAsync } from './liquidity';
+export { buildBurnTx, buildCollectTx, estimateRemoveAmounts, estimateRemoveAmountsAsync, ValidationError } from './liquidity';
 export type { BurnTxParams, CollectTxParams, UnsignedTx, BurnUnsignedTx, CollectUnsignedTx, RemoveAmountsResult, RemoveAmountsParams } from './liquidity';
 
 // #69 — Pool query helpers
@@ -9,5 +9,5 @@ export { getPool, getPosition, getPositionWithLoading, getTick, EMPTY_POSITION_M
 export type { PoolState, PositionState, TickState } from './types';
 export { SwyftRpcError } from './types';
 
-export { buildSwapTx, toStellarAddress, toRawAmount, toXdrBase64 } from './swap';
+export { buildSwapTx, toStellarAddress, toRawAmount, toXdrBase64, SwapValidationError } from './swap';
 export type { PoolId, SwapTxParams, SwapUnsignedTx, StellarAddress, RawAmount, XdrBase64 } from './swap';

--- a/packages/sdk/src/liquidity.ts
+++ b/packages/sdk/src/liquidity.ts
@@ -10,6 +10,19 @@ export interface CollectTxParams {
   readonly positionId: string;
   readonly poolId: string;
   readonly ownerAddress: string;
+  /** Stellar wallet address of the fee collector. */
+  readonly ownerWallet: string;
+}
+
+function isValidStellarAddress(address: string): boolean {
+  return typeof address === "string" && address.length === 56 && address.startsWith("G");
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
 }
 
 /** Unsigned burn (remove-liquidity) transaction envelope. */
@@ -48,8 +61,18 @@ export function buildBurnTx(params: BurnTxParams): BurnUnsignedTx {
 /**
  * Builds an unsigned collect-fees transaction XDR.
  * Stub — replace with real Soroban contract invocation via stellar-sdk.
+ *
+ * @throws {ValidationError} If ownerWallet is not a valid Stellar address
  */
 export function buildCollectTx(params: CollectTxParams): CollectUnsignedTx {
+  if (!params.ownerWallet) {
+    throw new ValidationError("ownerWallet is required");
+  }
+  if (!isValidStellarAddress(params.ownerWallet)) {
+    throw new ValidationError(
+      `ownerWallet must be a valid Stellar address (starts with G, 56 chars). Got: ${params.ownerWallet}`
+    );
+  }
   const payload = JSON.stringify({ op: 'collect', ...params });
   const xdr = Buffer.from(payload).toString('base64');
   return { xdr, type: 'collect' };

--- a/packages/sdk/src/swap.ts
+++ b/packages/sdk/src/swap.ts
@@ -1,3 +1,12 @@
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  Networks,
+  xdr,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
 // ── Branded primitives ────────────────────────────────────────────────────────
 
 /**
@@ -70,19 +79,114 @@ export interface SwapUnsignedTx {
   readonly type: 'swap';
 }
 
+// ── Validation ────────────────────────────────────────────────────────────────
+
+function isValidStellarAddress(address: string): boolean {
+  return (
+    typeof address === "string" &&
+    address.length === 56 &&
+    (address.startsWith("G") || address.startsWith("C"))
+  );
+}
+
+function isValidAmount(amount: string): boolean {
+  try {
+    const num = parseFloat(amount);
+    return !isNaN(num) && num > 0 && Number.isFinite(num);
+  } catch {
+    return false;
+  }
+}
+
+export class SwapValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SwapValidationError";
+  }
+}
+
 // ── Builder ───────────────────────────────────────────────────────────────────
 
 /**
  * Builds an unsigned swap transaction XDR from provided swap parameters.
  *
- * The returned transaction is a stub payload that should be replaced with a
- * real Soroban router invocation in production.
+ * Constructs a real Soroban transaction that invokes the swap method on a router
+ * contract. The transaction is built with a placeholder source account and must be
+ * properly signed before submission.
  *
  * @param params - Swap parameters including pool ID, token IDs, amounts, and owner.
  * @returns An unsigned swap transaction envelope in base-64 XDR format.
+ * @throws {SwapValidationError} If parameters are invalid (invalid addresses or amounts).
  */
 export function buildSwapTx(params: SwapTxParams): SwapUnsignedTx {
-  const payload = JSON.stringify({ op: 'swap', ...params });
-  const xdr = btoa(payload) as XdrBase64;
-  return { xdr, type: 'swap' };
+  if (!isValidStellarAddress(params.poolId)) {
+    throw new SwapValidationError(
+      `Invalid poolId: must be a valid Stellar address. Got: ${params.poolId}`
+    );
+  }
+  if (!isValidStellarAddress(params.tokenInId)) {
+    throw new SwapValidationError(
+      `Invalid tokenInId: must be a valid Stellar address. Got: ${params.tokenInId}`
+    );
+  }
+  if (!isValidStellarAddress(params.tokenOutId)) {
+    throw new SwapValidationError(
+      `Invalid tokenOutId: must be a valid Stellar address. Got: ${params.tokenOutId}`
+    );
+  }
+  if (!isValidStellarAddress(params.ownerAddress)) {
+    throw new SwapValidationError(
+      `Invalid ownerAddress: must be a valid Stellar address. Got: ${params.ownerAddress}`
+    );
+  }
+  if (!isValidAmount(params.amountIn)) {
+    throw new SwapValidationError(
+      `Invalid amountIn: must be a positive number. Got: ${params.amountIn}`
+    );
+  }
+  if (!isValidAmount(params.minimumReceived)) {
+    throw new SwapValidationError(
+      `Invalid minimumReceived: must be a positive number. Got: ${params.minimumReceived}`
+    );
+  }
+
+  try {
+    const contract = new Contract(params.poolId);
+
+    const amountInScVal = nativeToScVal(params.amountIn, {
+      type: "i128",
+    });
+    const minOutScVal = nativeToScVal(params.minimumReceived, {
+      type: "i128",
+    });
+    const tokenInScVal = nativeToScVal(params.tokenInId, {
+      type: "address",
+    });
+    const tokenOutScVal = nativeToScVal(params.tokenOutId, {
+      type: "address",
+    });
+
+    const swapOp = contract.call("swap", tokenInScVal, tokenOutScVal, amountInScVal, minOutScVal);
+
+    const sourceKeypair = Keypair.random();
+    const sourceAccount = {
+      accountId: sourceKeypair.publicKey(),
+      sequence: "0",
+    };
+
+    const txBuilder = new TransactionBuilder(sourceAccount, {
+      fee: "100000",
+      networkPassphrase: Networks.TESTNET_NETWORK_PASSPHRASE,
+    });
+
+    txBuilder.addOperation(swapOp);
+    const tx = txBuilder.setTimeout(30).build();
+
+    const xdrString = tx.toEnvelope().toXDR("base64");
+    return { xdr: xdrString as XdrBase64, type: "swap" };
+  } catch (err) {
+    if (err instanceof SwapValidationError) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    throw new SwapValidationError(`Failed to build swap transaction: ${message}`);
+  }
 }


### PR DESCRIPTION
  ## Summary                 
closes #346                                                                                                                                                                                    
                                                                                                                                                                                                                
  Aligns the frontend candles hook with actual backend response shape, builds a comprehensive pool detail page powered by the new pool API endpoint, adds ownerWallet field validation to collect-fees requests,
   and implements real Soroban XDR transaction building for swap operations across the SDK.                                                                                                                     
                                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                                    
                                                                                                                                                                                                                
  ### #345 — Align usePriceCandles REST response parse                                                                                                                                                          
  - Map backend response structure from `{ data: [...] }` to expected `{ candles: [...] }`                                                                                                                      
  - Convert PriceCandleDto field names and types: `timestamp` → `time`, string values → numbers                                                                                                                 
  - Add type guard validation to filter and parse candles, returning empty array on malformed data                                                                                                              
  - Add unit tests covering correct parsing, malformed responses, fetch failures                                                                                                    
                                                                                                                                                                                                                
  ### #346 — Build pool detail page from API                                                                                                                                                                    
  - Create `usePoolDetail` hook using React Query to fetch full pool data from `/api/pools/:id`                                                                                                                 
  - Build responsive pool detail page displaying all PoolDetail fields in organized grid layout                                                                                                                 
  - Render token pair information with logos and addresses for both tokens                                                                                                                                      
  - Add loading skeleton UI and error state with retry button                                                                                                                                                   
  - Include Swap and Add Liquidity buttons with pre-filled navigation                                                                                                                                           
  - Add unit tests for successful data fetch, 404 handling, and null poolId scenarios                                                                                                                           
                                                                                                                                                                                                                
  ### #347 — Portfolio collect-fees ownerWallet field                                                                                                                                                           
  - Add `ownerWallet: string` field to CollectTxParams interface                                                                                                                                                
  - Implement Stellar address validation (56 chars, starts with 'G') in buildCollectTx                                                                                                                          
  - Return typed ValidationError on invalid address or missing field                                                                                                                                            
  - Update portfolio page to pass ownerWallet in collect-fees SDK call                                                                                                                                          
  - Add tests covering valid addresses, missing field, and invalid formats                                                                                                                                      
                                                                                                                                                                                                                
  ### #348 — Build real Soroban XDR in swap.ts                                                                                                                                                                  
  - Replace stub JSON encoding with real Soroban transaction construction                                                                                                                                     
  - Create Contract instance and invoke swap method with proper SC values (i128 for amounts, address for tokens)                                                                                                
  - Build TransactionBuilder with swap operation and sign-ready transaction envelope                                                                                                                            
  - Add comprehensive parameter validation for all addresses and amounts                                                                                                                                        
  - Export SwapValidationError for SDK consumers to handle invalid inputs                                                                                                                                       
  - Update tests to verify XDR validity and cover all validation error paths                                                                                                                                    
                                                                                                                                                                                                                
  ## Testing                                                                                                                                                                                                    
                                                                                                                                                                                                                
  - **#345**: Tests verify correct candle array parsing from actual response shape, empty array on malformed data, and error handling on fetch failure                                                          
  - **#346**: Tests verify pool data renders correctly from API, loading skeleton displays, 404 error state renders, null poolId doesn't trigger fetch
  - **#347**: Tests verify ownerWallet included in request payload, validation errors thrown for missing/invalid addresses, correct error messages                                                              
  - **#348**: Tests verify XDR string is valid base64, validation catches invalid addresses and amounts, different parameters produce different XDR                                                             
                                                                                                                                                                                                                
  ## Notes                                                                                                                                                                                                      
                                                                                                                                                                                                                
  - **Response shape mismatch**: Backend returns `{ data: PriceCandleDto[] }` where DTOs have `timestamp` (number), `open/high/low/close/volume` (strings). Frontend now correctly maps these to the Candle     
  interface.
  - **Pool detail page routing**: Follows Next.js app router convention with dynamic `[id]` segment at `app/pools/[id]/page.tsx`                                                                                
  - **Wallet context**: Portfolio page uses `position.ownerWallet` from position data returned by API; no additional context hook needed                                                                        
  - **Soroban XDR building**: Uses `@stellar/stellar-sdk` Contract class with `nativeToScVal` for proper SC value encoding. Builds stub transaction for signing (no simulation/submission in SDK).              
                                                                                                                                                                                                                
  Closes #345, Closes #346, Closes #347, Closes #348  