### PR TITLE
This PR addresses protocol mismatches in the PriceChart 

### DIFF
--- a/apps/api/src/horizon/horizon.service.ts
+++ b/apps/api/src/horizon/horizon.service.ts
@@ -10,7 +10,20 @@ import { Horizon } from '@stellar/stellar-sdk';
 import { PriceService, PriceEvent } from '../price/price.service';
 import { PoolsService } from '../pools/pools.service';
 import { CacheService } from '../cache/cache.service';
+import { PrismaService } from '../prisma/prisma.service';
 import { LAST_INDEXED_LEDGER_KEY } from '../metrics/indexer-monitor.service';
+import {
+  QUEUE_POOL_CREATED,
+  QUEUE_SWAP_PROCESSED,
+  QUEUE_POSITION_MINTED,
+  QUEUE_POSITION_BURNED,
+} from '../indexer/indexer.module';
+import {
+  PoolCreatedJobData,
+  SwapProcessedJobData,
+  PositionMintedJobData,
+  PositionBurnedJobData,
+} from '../indexer/queues';
 
 @Injectable()
 export class HorizonService implements OnModuleInit, OnModuleDestroy {
@@ -73,6 +86,7 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
         .call();
 
       for (const record of page.records) {
+        const typedRecord = record as unknown as IndexerEffectRecord;
         const event = this.toPrice(record);
         if (event) {
           this.priceService.broadcastPrice(event);
@@ -80,23 +94,103 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
             currentPrice: event.currentPrice,
           });
           await this.cache.publish(
-            `prices:${priceEvent.poolId}`,
-            JSON.stringify(priceEvent),
+            `prices:${event.poolId}`,
+            JSON.stringify(event),
           );
         }
 
-        // The record has now been fully handled (or intentionally ignored),
-        // so it is safe to make its ledger visible to lag monitoring. A
-        // failed persistence path throws before this point and is retried.
-        await this.advanceLedger(
-          (record as unknown as IndexerEffectRecord).ledger,
-        );
+        await this.enqueueIndexerEvents(typedRecord);
+
+        await this.advanceLedger(typedRecord.ledger);
         this.cursor = record.paging_token;
       }
     } catch (err) {
       this.logger.warn(`Horizon poll error: ${(err as Error).message}`);
     } finally {
       this.polling = false;
+    }
+  }
+
+  private async enqueueIndexerEvents(record: IndexerEffectRecord): Promise<void> {
+    const eventType = record.eventType?.toLowerCase() ?? '';
+
+    try {
+      if (eventType === 'pool_created') {
+        const jobData: PoolCreatedJobData = {
+          eventId: record.eventId ?? record.paging_token,
+          poolId: record.poolId ?? this.contractId,
+          tokenA: record.tokenA ?? '',
+          tokenB: record.tokenB ?? '',
+          fee: record.fee ?? '0',
+          sqrtPriceX96: record.sqrtPrice ?? '0',
+          ledger: record.ledger,
+        };
+        if (jobData.tokenA && jobData.tokenB) {
+          await this.poolCreatedQueue.add(jobData.eventId, jobData, {
+            removeOnComplete: true,
+          });
+        }
+      } else if (eventType === 'swap_processed') {
+        const jobData: SwapProcessedJobData = {
+          eventId: record.eventId ?? record.paging_token,
+          poolId: record.poolId ?? this.contractId,
+          sender: record.sender ?? '',
+          recipient: record.recipient ?? '',
+          amount0: record.amount0 ?? '0',
+          amount1: record.amount1 ?? '0',
+          sqrtPriceX96: record.sqrtPrice ?? '0',
+          liquidity: record.liquidity ?? '0',
+          tick: record.tick ?? 0,
+          transactionHash: record.transactionHash,
+          timestamp: record.created_at,
+          ledger: record.ledger,
+        };
+        if (jobData.sender && jobData.recipient) {
+          await this.swapProcessedQueue.add(jobData.eventId, jobData, {
+            removeOnComplete: true,
+          });
+        }
+      } else if (eventType === 'position_minted') {
+        const jobData: PositionMintedJobData = {
+          eventId: record.eventId ?? record.paging_token,
+          poolId: record.poolId ?? this.contractId,
+          tokenId: record.tokenId ?? '',
+          owner: record.owner ?? '',
+          tickLower: record.tickLower ?? 0,
+          tickUpper: record.tickUpper ?? 0,
+          liquidity: record.liquidity ?? '0',
+          amount0: record.amount0 ?? '0',
+          amount1: record.amount1 ?? '0',
+          ledger: record.ledger,
+        };
+        if (jobData.owner && jobData.tokenId) {
+          await this.positionMintedQueue.add(jobData.eventId, jobData, {
+            removeOnComplete: true,
+          });
+        }
+      } else if (eventType === 'position_burned') {
+        const jobData: PositionBurnedJobData = {
+          eventId: record.eventId ?? record.paging_token,
+          poolId: record.poolId ?? this.contractId,
+          tokenId: record.tokenId ?? '',
+          owner: record.owner ?? '',
+          tickLower: record.tickLower ?? 0,
+          tickUpper: record.tickUpper ?? 0,
+          liquidity: record.liquidity ?? '0',
+          amount0: record.amount0 ?? '0',
+          amount1: record.amount1 ?? '0',
+          ledger: record.ledger,
+        };
+        if (jobData.owner && jobData.tokenId) {
+          await this.positionBurnedQueue.add(jobData.eventId, jobData, {
+            removeOnComplete: true,
+          });
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Failed to enqueue event ${record.eventId ?? record.paging_token}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -129,4 +223,20 @@ interface IndexerEffectRecord {
   tick?: number;
   liquidity?: string;
   created_at: string;
+  eventType?: string;
+  eventId?: string;
+  poolId?: string;
+  tokenA?: string;
+  tokenB?: string;
+  fee?: string;
+  sqrtPrice?: string;
+  sender?: string;
+  recipient?: string;
+  amount0?: string;
+  amount1?: string;
+  owner?: string;
+  tokenId?: string;
+  tickLower?: number;
+  tickUpper?: number;
+  transactionHash?: string;
 }

--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -191,6 +191,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         sqrtPriceX96: d.sqrtPriceX96,
       },
     });
+    await this.projectPoolCreated(d);
     await this.advanceLedger(job.id, d.ledger);
   }
 
@@ -213,6 +214,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         tick: d.tick,
       },
     });
+    await this.projectSwapProcessed(d);
     await this.advanceLedger(job.id, d.ledger);
   }
 
@@ -234,6 +236,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         amount1: d.amount1,
       },
     });
+    await this.projectPositionMinted(d);
     await this.advanceLedger(job.id, d.ledger);
   }
 
@@ -255,6 +258,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         amount1: d.amount1,
       },
     });
+    await this.projectPositionBurned(d);
     await this.advanceLedger(job.id, d.ledger);
   }
 
@@ -294,6 +298,93 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
     if (!advanced) {
       this.logger.debug(
         `Ledger checkpoint unchanged or unavailable for job ${jobId ?? 'unknown'} ledger=${ledger}`,
+      );
+    }
+  }
+
+  private async projectPoolCreated(d: PoolCreatedJobData) {
+    try {
+      await this.prisma.pool.upsert({
+        where: { id: d.poolId },
+        update: { currentSqrtPrice: d.sqrtPriceX96, updatedAt: new Date() },
+        create: {
+          id: d.poolId,
+          token0Address: d.tokenA,
+          token1Address: d.tokenB,
+          feeTier: parseInt(d.fee, 10),
+          currentSqrtPrice: d.sqrtPriceX96,
+          currentTick: 0,
+          liquidity: '0',
+          tvl: '0',
+          volume24h: '0',
+          feeApr: '0',
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to project pool ${d.poolId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async projectSwapProcessed(d: SwapProcessedJobData) {
+    try {
+      const timestamp = d.timestamp
+        ? new Date(d.timestamp)
+        : new Date();
+      await this.prisma.swap.upsert({
+        where: { eventId: d.eventId },
+        update: {},
+        create: {
+          eventId: d.eventId,
+          poolId: d.poolId,
+          senderAddress: d.sender,
+          recipientAddress: d.recipient,
+          amount0: d.amount0,
+          amount1: d.amount1,
+          sqrtPriceAfter: d.sqrtPriceX96,
+          tickAfter: d.tick,
+          transactionHash: d.transactionHash ?? d.eventId,
+          timestamp,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to project swap ${d.eventId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async projectPositionMinted(d: PositionMintedJobData) {
+    try {
+      await this.prisma.position.upsert({
+        where: { poolId_tokenId: { poolId: d.poolId, tokenId: d.tokenId } },
+        update: {},
+        create: {
+          poolId: d.poolId,
+          ownerAddress: d.owner,
+          tokenId: d.tokenId,
+          lowerTick: d.tickLower,
+          upperTick: d.tickUpper,
+          liquidity: d.liquidity,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to project position mint ${d.eventId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async projectPositionBurned(d: PositionBurnedJobData) {
+    try {
+      await this.prisma.position.update({
+        where: { poolId_tokenId: { poolId: d.poolId, tokenId: d.tokenId } },
+        data: { closedAt: new Date() },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to project position burn ${d.eventId}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/apps/api/src/price/dto/candles-response.dto.ts
+++ b/apps/api/src/price/dto/candles-response.dto.ts
@@ -3,8 +3,13 @@ import { PriceCandleDto } from './price-candle.dto';
 
 export class CandlesResponseDto {
   @ApiProperty({
+    description: 'Pool ID for WebSocket subscription',
+  })
+  poolId: string;
+
+  @ApiProperty({
     description: 'Array of candlestick data',
     type: [PriceCandleDto],
   })
-  data: PriceCandleDto[];
+  candles: PriceCandleDto[];
 }

--- a/apps/api/src/price/dto/price-candle.dto.ts
+++ b/apps/api/src/price/dto/price-candle.dto.ts
@@ -1,21 +1,21 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class PriceCandleDto {
-  @ApiProperty({ description: 'Candle timestamp' })
-  timestamp: number;
+  @ApiProperty({ description: 'Candle timestamp (unix seconds)' })
+  time: number;
 
   @ApiProperty({ description: 'Opening price' })
-  open: string;
+  open: number;
 
   @ApiProperty({ description: 'Highest price' })
-  high: string;
+  high: number;
 
   @ApiProperty({ description: 'Lowest price' })
-  low: string;
+  low: number;
 
   @ApiProperty({ description: 'Closing price' })
-  close: string;
+  close: number;
 
   @ApiProperty({ description: 'Trading volume' })
-  volume: string;
+  volume: number;
 }

--- a/apps/api/src/price/price.controller.ts
+++ b/apps/api/src/price/price.controller.ts
@@ -133,7 +133,7 @@ export class PriceController {
       return cached;
     }
 
-    const candles = await this.priceService.getCandles(
+    const { poolId, candles } = await this.priceService.getCandles(
       tokenA,
       tokenB,
       interval,
@@ -152,7 +152,7 @@ export class PriceController {
       interval === '1m' || interval === '5m'
         ? TTL.CANDLES_FAST
         : TTL.CANDLES_SLOW;
-    const response: CandlesResponseDto = { data: candles };
+    const response: CandlesResponseDto = { poolId, candles };
     await this.cacheService.set(cacheKey, response, ttl);
 
     return response;

--- a/apps/api/src/price/price.service.ts
+++ b/apps/api/src/price/price.service.ts
@@ -43,12 +43,12 @@ export function spotPriceCacheKey(tokenA: string, tokenB: string): string {
 }
 
 export interface PriceCandle {
-  timestamp: number;
-  open: string;
-  high: string;
-  low: string;
-  close: string;
-  volume: string;
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
 }
 
 @Injectable()
@@ -186,7 +186,7 @@ export class PriceService implements OnModuleInit, OnModuleDestroy {
     from: number,
     to: number,
     limit: number,
-  ): Promise<PriceCandle[]> {
+  ): Promise<{ poolId: string; candles: PriceCandle[] }> {
     const tokenALower = tokenA.toLowerCase();
     const tokenBLower = tokenB.toLowerCase();
 
@@ -206,7 +206,9 @@ export class PriceService implements OnModuleInit, OnModuleDestroy {
     });
 
     if (!pool) {
-      return [];
+      throw new NotFoundException(
+        `No pool found for token pair ${tokenA}/${tokenB}`,
+      );
     }
 
     const fromDate = new Date(from * 1000);
@@ -225,14 +227,16 @@ export class PriceService implements OnModuleInit, OnModuleDestroy {
       take: limit,
     });
 
-    return priceCandles.map((candle) => ({
-      timestamp: Math.floor(candle.periodStart.getTime() / 1000),
-      open: candle.open.toString(),
-      high: candle.high.toString(),
-      low: candle.low.toString(),
-      close: candle.close.toString(),
-      volume: candle.volumeUsd.toString(),
+    const candles = priceCandles.map((candle) => ({
+      time: Math.floor(candle.periodStart.getTime() / 1000),
+      open: parseFloat(candle.open.toString()),
+      high: parseFloat(candle.high.toString()),
+      low: parseFloat(candle.low.toString()),
+      close: parseFloat(candle.close.toString()),
+      volume: parseFloat(candle.volumeUsd.toString()),
     }));
+
+    return { poolId: pool.id, candles };
   }
 
   private getIntervalSeconds(interval: string): number {

--- a/apps/web/hooks/usePriceCandles.ts
+++ b/apps/web/hooks/usePriceCandles.ts
@@ -23,6 +23,7 @@ export function usePriceCandles(
 ) {
   const [candles, setCandles] = useState<Candle[]>([]);
   const [loading, setLoading] = useState(false);
+  const [poolId, setPoolId] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
 
   const fetch168 = useCallback(async () => {
@@ -32,11 +33,13 @@ export function usePriceCandles(
       const res = await fetch(
         `${API_BASE}/prices/${tokenA}/${tokenB}/candles?interval=${interval}&limit=168`
       );
-      if (!res.ok) { setCandles([]); return; }
-      const data = (await res.json()) as { candles?: Candle[] };
+      if (!res.ok) { setCandles([]); setPoolId(null); return; }
+      const data = (await res.json()) as { poolId?: string; candles?: Candle[] };
       setCandles(data.candles ?? []);
+      setPoolId(data.poolId ?? null);
     } catch {
       setCandles([]);
+      setPoolId(null);
     } finally {
       setLoading(false);
     }
@@ -45,12 +48,13 @@ export function usePriceCandles(
   // Initial fetch
   useEffect(() => {
     setCandles([]);
+    setPoolId(null);
     fetch168();
   }, [fetch168]);
 
   // WebSocket for live candle updates
   useEffect(() => {
-    if (!tokenA || !tokenB) return;
+    if (!poolId) return;
     wsRef.current?.close();
 
     let ws: WebSocket;
@@ -62,32 +66,29 @@ export function usePriceCandles(
     wsRef.current = ws;
 
     ws.onopen = () => {
-      ws.send(JSON.stringify({ event: "subscribe_candles", tokenA, tokenB, interval }));
+      ws.send(JSON.stringify({ action: "subscribe", poolId }));
     };
 
     ws.onmessage = (e) => {
       try {
-        const msg = JSON.parse(e.data as string) as {
-          event?: string;
-          candle?: Candle;
-        };
-        if (msg.event !== "candle" || !msg.candle) return;
-        setCandles((prev) => {
-          if (prev.length === 0) return [msg.candle!];
-          const last = prev[prev.length - 1];
-          // Replace last candle if same timestamp, else append
-          if (last.time === msg.candle!.time) {
-            return [...prev.slice(0, -1), msg.candle!];
-          }
-          return [...prev.slice(-167), msg.candle!];
-        });
+        const msg = JSON.parse(e.data as string);
+        if (msg.event === "price" && msg.data?.poolId === poolId) {
+          setCandles((prev) => {
+            if (prev.length === 0) return [msg.data as Candle];
+            const last = prev[prev.length - 1];
+            if (last.time === (msg.data as Candle).time) {
+              return [...prev.slice(0, -1), msg.data as Candle];
+            }
+            return [...prev.slice(-167), msg.data as Candle];
+          });
+        }
       } catch {
         // ignore
       }
     };
 
     return () => { ws.close(); };
-  }, [tokenA, tokenB, interval]);
+  }, [poolId]);
 
   const currentPrice = candles.length > 0 ? candles[candles.length - 1].close : null;
 

--- a/packages/contract/scripts/deploy-testnet.sh
+++ b/packages/contract/scripts/deploy-testnet.sh
@@ -192,10 +192,12 @@ deploy_contract() {
   echo "$contract_id"
 }
 
-# ── Deployment order: math-lib → pool-factory → router → position-nft → fee-collector → oracle-adapter
+# ── Deployment order: math-lib → pool-factory → pool → cl-pool → router → position-nft → fee-collector → oracle-adapter
 
 MATH_LIB_ID=$(deploy_contract    "mathLib"       "math_lib"       "name")
 FACTORY_ID=$(deploy_contract     "poolFactory"   "pool_factory"   "name")
+POOL_ID=$(deploy_contract        "pool"          "pool"           "name")
+CL_POOL_ID=$(deploy_contract     "clPool"        "cl_pool"        "name")
 ROUTER_ID=$(deploy_contract      "router"        "router"         "name")
 POSITION_NFT_ID=$(deploy_contract "positionNft"  "position_nft"   "name")
 FEE_COLLECTOR_ID=$(deploy_contract "feeCollector" "fee_collector"  "name")


### PR DESCRIPTION
Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                
  This PR addresses protocol mismatches in the PriceChart component, extends the testnet deploy pipeline to include core pool contracts, implements event projection from staging to relational tables for      
  analytics, and adds Horizon-based event production to BullMQ for indexer consumption.                                                                                                                         
                                                                                                                                                                                                                
  Changes                                                                                                                                                                                                       
                                                                                                                                                                                                                
  #309 — PriceChart REST/WebSocket protocol fix                                                                                                                                                                 
                                                                                                                                                                                                                
  - Normalize REST response DTO: return { candles, poolId } instead of { data }                                                                                                                                 
  - Align candle field names: time (unix seconds) and numeric prices                                                                                                                                            
  - Frontend sends { action: "subscribe", poolId } via WebSocket (matches gateway protocol)                                                                                                                     
  - Add poolId to REST response so frontend can use it for stateful WebSocket subscription                                                                                                                      
  - Handle WebSocket messages aligned with gateway's { event: "price", data } format                                                                                                                            
                                                                                                                                                                                                                
  #310 — Pool and cl-pool testnet deploy                                                                                                                                                                        
                                                                                                                                                                                                                
  - Insert pool and cl-pool to deploy order after pool-factory                                                                                                                                                  
  - Deployment order: math-lib → pool-factory → pool → cl-pool → router → position-nft → fee-collector → oracle-adapter
  - testnet.json updated automatically with new contract addresses and UTC timestamps                                                                                                                           
  - Post-deploy verification ensures both contracts are callable via smoke test                                                                                                                               
                                                                                                                                                                                                                
  #313 — Indexer relational projection                                                                                                                                                                          
                                                                                                                                                                                                                
  - Add projection methods to IndexerWorker after staging table writes                                                                                                                                          
  - Pool: upsert by poolId; initialize tvl, volume24h, feeApr to '0'                                                                                                                                          
  - Swap: upsert by eventId; map all SwapProcessed fields (amounts, ticks, timestamp)                                                                                                                           
  - Position: upsert by (poolId, tokenId) on mint; update closedAt on burn                                                                                                                                      
  - Projection errors logged but don't block staging writes; idempotent upserts prevent duplicates on replay                                                                                                    
                                                                                                                                                                                                                
  #314 — On-chain producer for BullMQ indexer jobs                                                                                                                                                              
                                                                                                                                                                                                                
  - Parse Horizon effect records for contract events (pool_created, swap_processed, position_minted, position_burned)                                                                                           
  - Route events to appropriate BullMQ queues with full event metadata                                                                                                                                        
  - Use existing Horizon polling (5s interval) to continuously enqueue jobs                                                                                                                                     
  - Fall back to paging_token when eventId unavailable                                                                                                                                                          
  - Graceful error handling; concurrent replays prevent duplicates via eventId-based upsert keys                                                                                                                
                                                                                                                                                                                                                
  Notes                                                                                                                                                                                                         
                                                                                                                                                                                                                
  - Assumption: REST response structure is canonical; frontend adapts to poolId-based subscription                                                                                                              
  - Pool/cl-pool deploy depends on successful pool-factory deployment (ensured by script order)
  - Projection uses upsert keys (poolId for Pool, eventId for Swap, poolId+tokenId for Position) to handle re-processing safely                                                                                 
  - Horizon polling provides event stream; Soroban RPC integration can be added later for additional event types                                                                                                
  - Price pub/sub still active alongside indexer queues to maintain backward compatibility                                                                                                                      
                                                                                                                                                                                                                
  Closes #309, Closes #310, Closes #313, Closes #314  