### PR TITLE
feat: resolve issues #350, #352, #354, #356

### DIFF
--- a/apps/api/src/indexer/indexer.module.ts
+++ b/apps/api/src/indexer/indexer.module.ts
@@ -4,6 +4,7 @@ import { IndexerController } from './indexer.controller';
 import { createQueue, QUEUE_NAMES } from './queues';
 import { CacheModule } from '../cache/cache.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
+import { TokensModule } from '../tokens/tokens.module';
 
 export const QUEUE_POOL_CREATED = 'QUEUE_POOL_CREATED';
 export const QUEUE_SWAP_PROCESSED = 'QUEUE_SWAP_PROCESSED';
@@ -12,7 +13,7 @@ export const QUEUE_POSITION_BURNED = 'QUEUE_POSITION_BURNED';
 export const QUEUE_FEES_COLLECTED = 'QUEUE_FEES_COLLECTED';
 
 @Module({
-  imports: [CacheModule, WebhooksModule],
+  imports: [CacheModule, WebhooksModule, TokensModule],
   controllers: [IndexerController],
   providers: [
     IndexerWorker,

--- a/apps/api/src/indexer/indexer.spec.ts
+++ b/apps/api/src/indexer/indexer.spec.ts
@@ -69,6 +69,10 @@ const mockWebhooksService = {
   dispatch: jest.fn().mockResolvedValue(undefined),
 };
 
+const mockTokenEnrichmentService = {
+  enrichToken: jest.fn().mockResolvedValue(undefined),
+};
+
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => mockPrismaClient),
 }));
@@ -79,6 +83,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { IndexerWorker } from './indexer.worker';
 import { CacheService } from '../cache/cache.service';
 import { WebhooksService } from '../webhooks/webhooks.service';
+import { TokenEnrichmentService } from '../tokens/token-enrichment.service';
 import { LAST_INDEXED_LEDGER_KEY } from '../metrics/indexer-monitor.service';
 import {
   IndexerModule,
@@ -271,6 +276,7 @@ describe('IndexerWorker', () => {
         IndexerWorker,
         { provide: CacheService, useValue: mockCacheService },
         { provide: WebhooksService, useValue: mockWebhooksService },
+        { provide: TokenEnrichmentService, useValue: mockTokenEnrichmentService },
       ],
     }).compile();
 
@@ -477,6 +483,14 @@ describe('IndexerWorker', () => {
       await expect(handler(makeJob(data))).resolves.not.toThrow();
 
       expect(mockPrismaClient.poolCreated.upsert).toHaveBeenCalled();
+    });
+
+    it('calls enrichToken for both pool tokens after pool is persisted', async () => {
+      const handler = getHandlerForQueue(QUEUE_NAMES.POOL_CREATED);
+      await handler(makeJob(data));
+
+      expect(mockTokenEnrichmentService.enrichToken).toHaveBeenCalledWith(data.tokenA);
+      expect(mockTokenEnrichmentService.enrichToken).toHaveBeenCalledWith(data.tokenB);
     });
   });
 

--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -8,6 +8,7 @@ import { Worker, Job, QueueEvents } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
 import { CacheService } from '../cache/cache.service';
 import { WebhooksService } from '../webhooks/webhooks.service';
+import { TokenEnrichmentService } from '../tokens/token-enrichment.service';
 import { LAST_INDEXED_LEDGER_KEY } from '../metrics/indexer-monitor.service';
 import {
   QUEUE_NAMES,
@@ -32,6 +33,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
   constructor(
     private readonly cache: CacheService,
     private readonly webhooks: WebhooksService,
+    private readonly tokenEnrichment: TokenEnrichmentService,
   ) {}
 
   get isLoading(): boolean {
@@ -417,6 +419,12 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
           feeApr: '0',
         },
       });
+
+      // Enrich both tokens with on-chain metadata after the pool is persisted.
+      await Promise.allSettled([
+        this.tokenEnrichment.enrichToken(d.tokenA),
+        this.tokenEnrichment.enrichToken(d.tokenB),
+      ]);
     } catch (err) {
       this.logger.error(
         `Failed to project pool ${d.poolId}: ${err instanceof Error ? err.message : String(err)}`,

--- a/apps/api/src/stats/stats.spec.ts
+++ b/apps/api/src/stats/stats.spec.ts
@@ -1,0 +1,246 @@
+// ─── BullMQ mock ─────────────────────────────────────────────────────────────
+
+const mockQueueAdd = jest.fn().mockResolvedValue({ id: 'stats-job-1' });
+const MockQueue = jest.fn().mockImplementation((name: string) => ({
+  name,
+  add: mockQueueAdd,
+  close: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockWorkerOn = jest.fn();
+const MockWorker = jest.fn().mockImplementation((_name: string) => ({
+  name: _name,
+  on: mockWorkerOn,
+  close: jest.fn().mockResolvedValue(undefined),
+  client: Promise.resolve({ llen: jest.fn().mockResolvedValue(0) }),
+}));
+
+jest.mock('bullmq', () => ({
+  Queue: MockQueue,
+  Worker: MockWorker,
+  Job: jest.fn(),
+}));
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────────
+
+const mockPools = [
+  { id: 'pool-1', token0Address: 'TOKENA', token1Address: 'TOKENB', feeTier: 3000 },
+];
+
+const mockSwaps24h = [
+  { amount0: '1000000', amount1: '-500000' },
+  { amount0: '2000000', amount1: '-1000000' },
+];
+
+const mockSwaps7d = [
+  ...mockSwaps24h,
+  { amount0: '500000', amount1: '-250000' },
+];
+
+const mockPositions = [{ liquidity: '1000000000' }];
+
+const mockPoolUpdate = jest.fn().mockResolvedValue({});
+const mockFindManyPools = jest.fn().mockResolvedValue(mockPools);
+const mockFindManySwaps = jest.fn();
+const mockFindManyPositions = jest.fn().mockResolvedValue(mockPositions);
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    pool: { findMany: mockFindManyPools, update: mockPoolUpdate },
+    swap: { findMany: mockFindManySwaps },
+    position: { findMany: mockFindManyPositions },
+    $disconnect: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScheduleModule } from '@nestjs/schedule';
+import { StatsScheduler, STATS_QUEUE } from './stats.scheduler';
+import { StatsWorker } from './stats.worker';
+import { StatsModule } from './stats.module';
+import { CacheService } from '../cache/cache.service';
+import { STATS_JOB_NAME } from './stats.queue';
+import { defaultJobOptions } from '../indexer/queues';
+import { Job } from 'bullmq';
+
+// ─── StatsScheduler (#354) ────────────────────────────────────────────────────
+
+describe('StatsScheduler', () => {
+  let scheduler: StatsScheduler;
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    module = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [
+        StatsScheduler,
+        { provide: STATS_QUEUE, useValue: { add: mockQueueAdd } },
+      ],
+    }).compile();
+
+    scheduler = module.get<StatsScheduler>(StatsScheduler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('is defined after AppModule wires StatsModule', () => {
+    expect(scheduler).toBeDefined();
+  });
+
+  it('enqueues a pool-stats job when scheduleAggregation is called', async () => {
+    await scheduler.scheduleAggregation();
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      STATS_JOB_NAME,
+      {},
+      expect.objectContaining({
+        jobId: expect.stringMatching(/^pool-stats-\d+$/),
+      }),
+    );
+  });
+
+  it('deduplicates within the same 5-minute window via stable jobId', async () => {
+    await scheduler.scheduleAggregation();
+    await scheduler.scheduleAggregation();
+
+    const [first, second] = mockQueueAdd.mock.calls;
+    expect(first[2].jobId).toBe(second[2].jobId);
+  });
+
+  it('includes defaultJobOptions in the enqueue call', async () => {
+    await scheduler.scheduleAggregation();
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      expect.any(String),
+      {},
+      expect.objectContaining({ attempts: defaultJobOptions.attempts }),
+    );
+  });
+});
+
+// ─── StatsModule compiles with ScheduleModule (#354) ─────────────────────────
+
+describe('StatsModule', () => {
+  let module: TestingModule;
+  const mockCacheService = { get: jest.fn().mockResolvedValue(null) };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    module = await Test.createTestingModule({ imports: [StatsModule] })
+      .overrideProvider(CacheService)
+      .useValue(mockCacheService)
+      .compile();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('compiles without errors', () => {
+    expect(module).toBeDefined();
+  });
+
+  it('provides StatsScheduler', () => {
+    expect(module.get(StatsScheduler)).toBeDefined();
+  });
+
+  it('provides StatsWorker', () => {
+    expect(module.get(StatsWorker)).toBeDefined();
+  });
+});
+
+// ─── StatsWorker — volume24h from Swap timestamps (#356) ─────────────────────
+
+describe('StatsWorker — volume24h from swap timestamps', () => {
+  let worker: StatsWorker;
+  let module: TestingModule;
+  let processJob: (job: Job) => Promise<void>;
+  const mockCacheService = { get: jest.fn().mockResolvedValue(null) };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockFindManySwaps.mockImplementation(
+      ({ where }: { where: { timestamp: { gte: Date } } }) => {
+        const cutoff = where.timestamp.gte.getTime();
+        const now = Date.now();
+        const ms24h = 24 * 60 * 60 * 1000;
+        const ms7d = 7 * ms24h;
+        if (Math.abs(cutoff - (now - ms24h)) < 60_000) return Promise.resolve(mockSwaps24h);
+        if (Math.abs(cutoff - (now - ms7d)) < 60_000) return Promise.resolve(mockSwaps7d);
+        return Promise.resolve([]);
+      },
+    );
+
+    module = await Test.createTestingModule({
+      providers: [
+        StatsWorker,
+        { provide: CacheService, useValue: mockCacheService },
+      ],
+    }).compile();
+
+    worker = module.get<StatsWorker>(StatsWorker);
+    worker.onModuleInit();
+
+    // Extract the process callback registered with the BullMQ Worker constructor
+    const workerCall = MockWorker.mock.calls.find((c) => c[0] === 'stats.aggregate');
+    processJob = workerCall![1] as (job: Job) => Promise<void>;
+    await processJob({} as Job);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('queries swaps using a Date-based timestamp filter', () => {
+    const swapCalls = mockFindManySwaps.mock.calls.filter(
+      (c: [{ where?: { timestamp?: unknown } }]) => c[0]?.where?.timestamp,
+    );
+    expect(swapCalls.length).toBeGreaterThanOrEqual(2);
+    for (const call of swapCalls) {
+      expect(call[0].where.timestamp.gte).toBeInstanceOf(Date);
+    }
+  });
+
+  it('uses Swap.timestamp (not job-enqueue time) as both the 24h and 7d window cutoffs', () => {
+    const now = Date.now();
+    const cutoffs = mockFindManySwaps.mock.calls
+      .filter((c: [{ where?: { timestamp?: { gte?: Date } } }]) => c[0]?.where?.timestamp?.gte)
+      .map((c: [{ where: { timestamp: { gte: Date } } }]) => c[0].where.timestamp.gte.getTime());
+
+    const ago24h = now - 24 * 60 * 60 * 1000;
+    const ago7d = now - 7 * 24 * 60 * 60 * 1000;
+
+    expect(cutoffs.some((t: number) => Math.abs(t - ago24h) < 60_000)).toBe(true);
+    expect(cutoffs.some((t: number) => Math.abs(t - ago7d) < 60_000)).toBe(true);
+  });
+
+  it('computes volume24h as sum of |amount0| + |amount1| across 24h swaps (price=1)', () => {
+    // swap1: |1000000| + |500000| = 1500000
+    // swap2: |2000000| + |1000000| = 3000000 → total 4500000
+    expect(mockPoolUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ volume24h: '4500000' }),
+      }),
+    );
+  });
+
+  it('persists volume24h, tvl, and feeApr in one pool update', () => {
+    expect(mockPoolUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'pool-1' },
+        data: expect.objectContaining({
+          volume24h: expect.any(String),
+          tvl: expect.any(String),
+          feeApr: expect.any(String),
+        }),
+      }),
+    );
+  });
+});

--- a/packages/sdk/src/__tests__/queries.spec.ts
+++ b/packages/sdk/src/__tests__/queries.spec.ts
@@ -37,6 +37,17 @@ beforeEach(() => {
 });
 
 describe('getPool', () => {
+  it('calls the get_state contract method', async () => {
+    mockSimulate.mockResolvedValue({ result: { retval: {} }, error: undefined });
+    (scValToNative as unknown as jest.Mock).mockReturnValue({
+      sqrt_price: '0', current_tick: 0, liquidity: '0', fee_tier: 0, token0: '', token1: '',
+    });
+
+    await getPool({ rpcUrl: 'https://rpc.example.com', poolAddress: 'CPOOL' });
+
+    expect(mockCall).toHaveBeenCalledWith('get_state');
+  });
+
   it('returns typed PoolState on success', async () => {
     mockSimulate.mockResolvedValue({ result: { retval: {} }, error: undefined });
     (scValToNative as unknown as jest.Mock).mockReturnValue({

--- a/packages/sdk/src/queries.ts
+++ b/packages/sdk/src/queries.ts
@@ -127,7 +127,7 @@ export async function getPool({
   rpcUrl: string;
   poolAddress: string;
 }): Promise<PoolState> {
-  const retval = await callContract(rpcUrl, poolAddress, 'get_pool_state');
+  const retval = await callContract(rpcUrl, poolAddress, 'get_state');
   const raw = assertRawObject(scValToNative(retval), poolAddress);
 
   return {


### PR DESCRIPTION
#350 — SDK: match contract method names to deploy
- Fix getPool() in packages/sdk/src/queries.ts to call 'get_state' instead of 'get_pool_state', matching the deployed pool contract's public fn name
- Add a test asserting the correct method name is passed to contract.call()

#352 — Tokens: call enrichToken on pool created
- Inject TokenEnrichmentService into IndexerWorker via constructor DI
- Import TokensModule in IndexerModule so the service is available
- After token stubs are upserted in projectPoolCreated(), call enrichToken(tokenA) and enrichToken(tokenB) via Promise.allSettled so a failed enrichment never aborts the pool projection
- Add test asserting both tokens are enriched after a pool.created event

#354 — Stats: verify StatsScheduler runs after AppModule fix
- Add apps/api/src/stats/stats.spec.ts with a StatsScheduler suite that compiles the scheduler inside a ScheduleModule.forRoot() context (matching AppModule's wiring) and asserts scheduleAggregation() enqueues a deduplicated pool-stats job with the correct options
- Add a StatsModule compile test confirming both StatsScheduler and StatsWorker are provided after module init

#356 — Stats: volume24h from swap timestamps
- Add StatsWorker test suite that extracts the BullMQ process callback and drives it directly; verifies that swap queries use Date-based timestamp filters anchored to the current time (24h and 7d windows), not job-enqueue time; confirms volume24h is computed correctly from swap amounts

Closes #350, Closes #352, Closes #354, Closes #356

## Summary

<!-- What does this PR do? -->

## Related issue

- Closes #

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Docs update
- [x] Chore / refactor

## Checklist

- [x] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [x] Docs updated if needed
