### PR TITLE
docs: add missing docs files and fix README paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,196 @@
+# Contributing to Swyft
+
+Thanks for your interest in contributing. Swyft is built almost entirely by external contributors — the maintainer handles architecture decisions, PR reviews, and releases. Contributors handle features.
+
+**Pick up an issue and open a PR — that's it.**
+
+---
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Development Setup](#development-setup)
+- [Finding Work](#finding-work)
+- [Branch and Commit Conventions](#branch-and-commit-conventions)
+- [Pull Request Process](#pull-request-process)
+- [Code Standards](#code-standards)
+- [Testing](#testing)
+- [Issue Labels](#issue-labels)
+
+---
+
+## Getting Started
+
+1. Fork the repository on GitHub.
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/Swyft.git
+   cd Swyft
+   ```
+3. Add the upstream remote:
+   ```bash
+   git remote add upstream https://github.com/Valreb001/Swyft.git
+   ```
+4. Follow the [Development Setup](#development-setup) section below.
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Node.js | ≥ 18 | Use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) |
+| pnpm | ≥ 8 | `npm install -g pnpm` |
+| Rust | stable | `rustup toolchain install stable` |
+| stellar-cli | latest | See [Stellar docs](https://developers.stellar.org/docs/smart-contracts/getting-started/setup) |
+| Docker | any | For local Postgres + Redis |
+
+### Install dependencies
+
+```bash
+pnpm install
+```
+
+### Configure environment
+
+```bash
+cp apps/api/.env.example apps/api/.env
+# Edit apps/api/.env — see Environment Variables section in README
+```
+
+### Start local services (Postgres + Redis)
+
+```bash
+cd apps/api
+docker compose up -d
+```
+
+### Run the full stack
+
+```bash
+pnpm dev
+```
+
+This starts the NestJS API and Next.js dApp simultaneously via Turborepo.
+
+### Run contract tests
+
+```bash
+cd packages/contract
+cargo test --workspace
+```
+
+### Run API tests
+
+```bash
+pnpm --filter api test
+```
+
+---
+
+## Finding Work
+
+- Browse [open issues](https://github.com/Valreb001/Swyft/issues)
+- Issues labelled [`good first issue`](https://github.com/Valreb001/Swyft/issues?q=label%3A%22good+first+issue%22) are well-scoped and don't require deep protocol knowledge
+- Issues labelled [`bounty`](https://github.com/Valreb001/Swyft/issues?q=label%3Abounty) have a financial reward attached
+- Comment on an issue before starting work to avoid duplication
+
+---
+
+## Branch and Commit Conventions
+
+Branch names follow the pattern:
+
+```
+<type>/<short-description>
+```
+
+Examples: `feat/multi-hop-router`, `fix/pool-tick-overflow`, `docs/update-readme`
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer: closes #<issue>]
+```
+
+Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`
+
+Examples:
+```
+feat(contracts): add tick spacing to pool factory
+fix(api): prevent duplicate nonce consumption
+docs: add CONTRIBUTING.md
+```
+
+---
+
+## Pull Request Process
+
+1. Branch from `main`:
+   ```bash
+   git checkout main
+   git pull upstream main
+   git checkout -b feat/your-feature
+   ```
+2. Make your changes, including tests.
+3. Ensure CI passes locally:
+   ```bash
+   pnpm lint
+   pnpm test
+   pnpm build
+   ```
+4. Push your branch and open a PR against `main`.
+5. Fill in the PR template — summary, testing steps, linked issue.
+6. One maintainer approval is required to merge.
+7. PRs are **squash-merged** — keep your commit history clean but it isn't strictly required.
+
+---
+
+## Code Standards
+
+- **TypeScript**: Strict mode enabled. No `any` without a comment explaining why.
+- **Rust**: `cargo clippy` must pass with no warnings. Follow standard Rust idioms.
+- **Formatting**: Run `pnpm format` before committing. Prettier config is at `.prettierrc`.
+- **Linting**: Run `pnpm lint` before committing. ESLint config is in each app/package.
+- **Accessibility**: Frontend components must meet WCAG 2.1 AA. Use semantic HTML and ARIA attributes where needed.
+
+---
+
+## Testing
+
+| Layer | How to run | Expectation |
+|---|---|---|
+| Soroban contracts | `cargo test --workspace` in `packages/contract` | All tests pass |
+| NestJS API unit | `pnpm --filter api test` | All tests pass |
+| NestJS API e2e | `pnpm --filter api test:e2e` | Requires running Postgres + Redis |
+| TypeScript SDK | `pnpm --filter @swyft/sdk test` | All tests pass |
+
+New features **must** include tests. Bug fixes **should** include a regression test.
+
+---
+
+## Issue Labels
+
+| Label | Meaning |
+|---|---|
+| `good first issue` | No deep protocol knowledge needed |
+| `bounty` | Financial reward attached |
+| `contracts` | Soroban / Rust work |
+| `backend` | NestJS / API work |
+| `frontend` | Next.js / React work |
+| `sdk` | TypeScript SDK work |
+| `docs` | Documentation |
+| `bug` | Something is broken |
+| `enhancement` | New feature or improvement |
+
+---
+
+## Questions?
+
+Open a [GitHub Discussion](https://github.com/Valreb001/Swyft/discussions) — the maintainer and community are there to help.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ swyft/
 │   ├── web/              # Next.js dApp
 │   └── api/              # NestJS backend
 ├── packages/
-│   ├── contracts/        # Soroban Rust contracts
+│   ├── contract/         # Soroban Rust contracts
 │   ├── sdk/              # @swyft/sdk (TypeScript)
 │   ├── ui/               # @swyft/ui shared components
 │   └── config/           # Shared ESLint, TS, Tailwind configs
@@ -65,7 +65,7 @@ swyft/
 
 ```bash
 # Clone the repo
-git clone https://github.com/Vatix-Protocol/Swyft.git
+git clone https://github.com/Valreb001/Swyft.git
 cd swyft
 
 # Install all dependencies
@@ -84,8 +84,8 @@ This starts the Next.js dApp, NestJS API, and watches contract changes simultane
 ### Run contract tests
 
 ```bash
-cd packages/contracts
-stellar-cli contract test
+cd packages/contract
+cargo test --workspace
 ```
 
 ### Run API tests
@@ -93,6 +93,30 @@ stellar-cli contract test
 ```bash
 pnpm --filter api test
 ```
+
+---
+
+## Environment Variables
+
+Copy `apps/api/.env.example` to `apps/api/.env` and fill in the values below.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `DATABASE_URL` | ✅ | `postgresql://postgres:postgres@localhost:5432/swyft` | PostgreSQL connection string (Prisma) |
+| `REDIS_URL` | ✅ | `redis://localhost:6379` | Redis connection string (BullMQ + cache) |
+| `STELLAR_NETWORK` | ✅ | `testnet` | `testnet` or `mainnet` |
+| `STELLAR_RPC_URL` | ✅ | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint |
+| `HORIZON_URL` | ✅ | `https://horizon-testnet.stellar.org` | Stellar Horizon endpoint |
+| `POOL_CONTRACT_ID` | ✅ | *(empty)* | Deployed pool contract address — see `packages/contract/deployments/testnet.json` |
+| `JWT_SECRET` | ✅ | `change-me-in-production` | Secret used to sign JWT tokens — **must be changed in production** |
+| `JWT_EXPIRES_IN` | ✅ | `7d` | JWT token lifetime |
+| `PORT` | ✅ | `3001` | HTTP port the API listens on |
+| `INTERNAL_API_KEY` | ✅ | `change-me-in-production` | Protects `/admin/*` and `/metrics/db` routes — **must be changed in production** |
+| `DB_SLOW_QUERY_THRESHOLD_MS` | ❌ | `100` | Queries slower than this (ms) are logged as warnings |
+| `SENTRY_DSN` | ❌ | *(empty)* | Sentry DSN for error tracking — leave blank to disable |
+| `SENTRY_TRACES_SAMPLE_RATE` | ❌ | `0.1` | Sentry trace sampling rate (0–1) |
+| `COMPRESSION_LEVEL` | ❌ | `6` | zlib compression level for HTTP responses (1–9) |
+| `WEBHOOK_LARGE_SWAP_USD` | ❌ | `10000` | USD threshold above which a swap triggers a webhook notification |
 
 ---
 
@@ -139,7 +163,7 @@ Swyft is built almost entirely by external contributors. The maintainer handles 
 
 ### Good first issues
 
-Look for issues labelled [`good first issue`](https://github.com/your-org/swyft/issues?q=label%3A%22good+first+issue%22). These are small, well-scoped tasks that don't require deep protocol knowledge.
+Look for issues labelled [`good first issue`](https://github.com/Valreb001/Swyft/issues?q=label%3A%22good+first+issue%22). These are small, well-scoped tasks that don't require deep protocol knowledge.
 
 ### Issue labels
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,96 @@
+# Security Policy
+
+## Scope
+
+This policy covers the Swyft monorepo, including:
+
+- Soroban smart contracts (`packages/contract/`)
+- NestJS backend API (`apps/api/`)
+- TypeScript SDK (`packages/sdk/`)
+- Next.js frontend (`apps/web/`)
+
+> **Important:** Swyft contracts are **unaudited**. Do not deploy to mainnet or use with real funds until a security audit has been completed and published.
+
+---
+
+## Supported Versions
+
+| Component | Supported |
+|---|---|
+| `main` branch | ✅ Yes |
+| Tagged releases | ✅ Yes |
+| Other branches | ❌ No |
+
+---
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.** Public disclosure before a fix is available puts users at risk.
+
+### How to report
+
+Send a report by email to the maintainer via GitHub. You can find the contact by navigating to the [repository owner's profile](https://github.com/Valreb001) and using the email listed there, or by opening a **private** [GitHub Security Advisory](https://github.com/Valreb001/Swyft/security/advisories/new).
+
+### What to include
+
+A useful report includes:
+
+1. **Description** — what is vulnerable and what the potential impact is
+2. **Reproduction steps** — a minimal example that demonstrates the issue
+3. **Affected component** — which package, contract, or endpoint is affected
+4. **Suggested fix** (optional) — if you have one
+
+### What to expect
+
+| Step | Timeline |
+|---|---|
+| Acknowledgement | Within 48 hours |
+| Initial assessment | Within 5 business days |
+| Fix or mitigation | Depends on severity — critical issues are prioritised immediately |
+| Public disclosure | After a fix is merged and released |
+
+---
+
+## Severity Classification
+
+We follow the [CVSS v3.1](https://www.first.org/cvss/v3.1/specification-document) scoring framework:
+
+| Severity | CVSS Score | Examples |
+|---|---|---|
+| Critical | 9.0–10.0 | Fund drainage, permanent contract lock |
+| High | 7.0–8.9 | Privilege escalation, fee manipulation |
+| Medium | 4.0–6.9 | Denial of service, info disclosure |
+| Low | 0.1–3.9 | Minor logic errors, non-exploitable edge cases |
+
+---
+
+## Smart Contract Specific Guidance
+
+Soroban contracts present unique risks. When reporting contract vulnerabilities, please consider:
+
+- **Reentrancy** — cross-contract call ordering
+- **Arithmetic overflow/underflow** — fixed-point math edge cases
+- **Access control** — admin function exposure
+- **Oracle manipulation** — TWAP price manipulation vectors
+- **Tick arithmetic** — off-by-one errors in concentrated liquidity math
+- **Storage exhaustion** — unbounded storage writes
+
+---
+
+## Disclosure Policy
+
+Swyft follows **coordinated disclosure**:
+
+1. Researcher reports privately.
+2. Maintainer confirms and assesses the issue.
+3. Fix is developed and tested.
+4. Fix is merged and a release is tagged.
+5. Public advisory is published with credit to the reporter (unless they prefer to remain anonymous).
+
+We will not take legal action against security researchers who follow this policy and act in good faith.
+
+---
+
+## Bug Bounty
+
+There is no formal bug bounty programme at this time. We will publicly acknowledge researchers who responsibly disclose valid vulnerabilities.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,95 @@
+# Swyft Roadmap
+
+This document outlines the planned development phases for Swyft — a concentrated-liquidity DEX on Stellar.
+
+> Timelines are approximate. Phase boundaries may shift based on audit schedules and contributor availability.
+
+---
+
+## Phase 0 — Foundation (M1–2) 🟡 In progress
+
+**Goal:** Establish the monorepo, CI pipeline, and contributor experience.
+
+- [x] Monorepo with Turborepo + pnpm workspaces
+- [x] GitHub Actions CI (lint, test, build)
+- [x] Contributor docs (`CONTRIBUTING.md`, `SECURITY.md`)
+- [x] Issue and PR templates
+- [x] Core Soroban contract scaffolding (math-lib, pool, router, position-nft, fee-collector, oracle-adapter)
+- [ ] Full contract test coverage
+- [ ] Local dev environment (Docker Compose)
+
+---
+
+## Phase 1 — Core Contracts (M2–5) ⚪ Planned
+
+**Goal:** Production-ready Soroban contracts with comprehensive tests.
+
+- [ ] Concentrated liquidity pool with tick-based accounting
+- [ ] Full math-lib coverage (sqrt, liquidity delta, fee growth)
+- [ ] Pool factory with registry
+- [ ] Multi-hop router
+- [ ] Position NFT with on-chain metadata
+- [ ] Fee collector with configurable protocol split
+- [ ] TWAP oracle adapter
+- [ ] 100% unit test coverage
+- [ ] Testnet deployment + verification
+
+---
+
+## Phase 2 — Backend & SDK (M4–7) ⚪ Planned
+
+**Goal:** Indexer, REST + WebSocket API, and TypeScript SDK.
+
+- [ ] Stellar Horizon event indexer (pool swaps, LP events)
+- [ ] PostgreSQL schema + Prisma migrations
+- [ ] Redis caching layer for pool state
+- [ ] REST API: pools, ticks, positions, swaps
+- [ ] WebSocket gateway: real-time price feeds
+- [ ] `@swyft/sdk` — TypeScript client for contracts + API
+- [ ] API authentication (wallet-based JWT)
+- [ ] Swagger / OpenAPI documentation
+
+---
+
+## Phase 3 — Frontend (M6–9) ⚪ Planned
+
+**Goal:** Fully functional dApp UI.
+
+- [ ] Swap interface (single-hop and multi-hop)
+- [ ] LP management (add/remove/rerange liquidity)
+- [ ] Pool browser with TVL, APR, volume charts
+- [ ] Portfolio dashboard (positions, unclaimed fees)
+- [ ] Freighter + xBull wallet integration
+- [ ] Mobile-responsive layout
+- [ ] Light / dark mode
+
+---
+
+## Phase 4 — Mainnet (M9–12) ⚪ Planned
+
+**Goal:** Secure public launch on Stellar mainnet.
+
+- [ ] Independent security audit of all Soroban contracts
+- [ ] Audit findings resolved and re-reviewed
+- [ ] Mainnet deployment
+- [ ] Liquidity bootstrap program
+- [ ] Public API (rate-limited, API key required)
+- [ ] Brand site + documentation portal
+
+---
+
+## Phase 5 — Growth (M12+) ⚪ Future
+
+**Goal:** Ecosystem expansion and protocol maturity.
+
+- [ ] Governance module (on-chain voting)
+- [ ] Multiple fee tiers (0.05%, 0.3%, 1%)
+- [ ] Aggregator integrations (1inch, Paraswap equivalents on Stellar)
+- [ ] Cross-chain bridging research
+- [ ] Grants program for ecosystem projects building on Swyft
+
+---
+
+## How to Influence the Roadmap
+
+Open a [GitHub Discussion](https://github.com/Valreb001/Swyft/discussions) with the `RFC` label to propose new features or changes to phase priorities. The maintainer reviews RFCs during each monthly planning cycle.


### PR DESCRIPTION
Summary

Closes #312 

What was implemented:

New files created:
- ROADMAP.md — full phase breakdown (Phase 0–5) with task checklists and a link to open GitHub Discussions for influencing priorities
- CONTRIBUTING.md — development setup, branch/commit conventions, PR process, code standards, testing table, and issue labels
- SECURITY.md — responsible disclosure policy, severity classification (CVSS), Soroban-specific vulnerability guidance, and disclosure timeline
- README.md fixes:
- [x] packages/contracts/ → packages/contract/ (actual directory name)
- [x] Clone URL Vatix-Protocol/Swyft → Valreb001/Swyft (matches the git remote)
- [x] Good-first-issue link your-org → Valreb001
- [x] Contract test command stellar-cli contract test → cargo test --workspace (correct for this repo)
- [x] Added a full environment variables reference table documenting all 15 vars from .env.example, including which are required vs optional