### PR TITLE
fix(pools): validate sqrt price on pool update

### DIFF
--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -18,6 +18,7 @@ import {
   PositionBurnedJobData,
   FeesCollectedJobData,
 } from './queues';
+import { PoolsRepository } from '../pools/pools.repository';
 
 @Injectable()
 export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
@@ -426,6 +427,31 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   private async projectSwapProcessed(d: SwapProcessedJobData) {
     try {
+      if (!PoolsRepository.isValidSqrtPrice(d.sqrtPriceX96)) {
+        this.logger.warn(
+          `Skipping pool state update for swap ${d.eventId} — invalid sqrtPriceX96: "${d.sqrtPriceX96}"`,
+        );
+        // Still persist the swap row; only skip the pool sqrt-price update.
+        const timestamp = d.timestamp ? new Date(d.timestamp) : new Date();
+        await this.prisma.swap.upsert({
+          where: { eventId: d.eventId },
+          update: {},
+          create: {
+            eventId: d.eventId,
+            poolId: d.poolId,
+            senderAddress: d.sender,
+            recipientAddress: d.recipient,
+            amount0: d.amount0,
+            amount1: d.amount1,
+            sqrtPriceAfter: d.sqrtPriceX96,
+            tickAfter: d.tick,
+            transactionHash: d.transactionHash ?? d.eventId,
+            timestamp,
+          },
+        });
+        return;
+      }
+
       const timestamp = d.timestamp ? new Date(d.timestamp) : new Date();
       await this.prisma.swap.upsert({
         where: { eventId: d.eventId },

--- a/apps/api/src/pools/pools.repository.ts
+++ b/apps/api/src/pools/pools.repository.ts
@@ -48,6 +48,17 @@ export class PoolsRepository {
     };
   }
 
+  /**
+   * Validates a raw sqrtPriceX96 string.
+   * A valid sqrt price must be a finite positive integer (Q64.96 fixed-point).
+   * Zero is rejected because it encodes an undefined price.
+   */
+  static isValidSqrtPrice(value: string | undefined | null): boolean {
+    if (!value || value.trim() === '') return false;
+    const n = BigInt(value.trim());
+    return n > 0n;
+  }
+
   async upsertPoolState(poolId: string, patch: PoolStatePatch): Promise<void> {
     if (patch.currentPrice === undefined) return;
 


### PR DESCRIPTION
## Summary

Adds validation of the `sqrtPriceX96` value before it is written to `pool.currentSqrtPrice` during swap projection.

### Changes

- **`PoolsRepository`**: adds a static `isValidSqrtPrice(value)` helper that rejects null/empty/zero/non-positive sqrt prices using BigInt comparison (mirrors the Q64.96 fixed-point contract invariant).
- **`IndexerWorker.projectSwapProcessed`**: gates the `pool.currentSqrtPrice` update behind `isValidSqrtPrice`. A malformed event still persists the `Swap` row for audit, but cannot corrupt the pool's tracked price.

### Validation

- TypeScript: no diagnostics on changed files
- Existing pre-existing repo-wide TS errors are unrelated (missing node_modules)

Closes #417