### PR TITLE
feat(swaps): store fee amount on swap row

### DIFF
--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -427,6 +427,24 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
   private async projectSwapProcessed(d: SwapProcessedJobData) {
     try {
       const timestamp = d.timestamp ? new Date(d.timestamp) : new Date();
+
+      // Look up the pool's feeTier to compute the fee amount for this swap.
+      // feeTier is stored in parts-per-million (e.g. 3000 = 0.3%).
+      let feeAmount = '0';
+      try {
+        const pool = await this.prisma.pool.findUnique({
+          where: { id: d.poolId },
+          select: { feeTier: true },
+        });
+        if (pool) {
+          const absAmount0 = Math.abs(Number(d.amount0));
+          const fee = absAmount0 * (pool.feeTier / 1_000_000);
+          feeAmount = Number.isFinite(fee) ? String(fee) : '0';
+        }
+      } catch {
+        // Non-fatal: fee computation failure must not block swap persistence.
+      }
+
       await this.prisma.swap.upsert({
         where: { eventId: d.eventId },
         update: {},
@@ -440,6 +458,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
           sqrtPriceAfter: d.sqrtPriceX96,
           tickAfter: d.tick,
           transactionHash: d.transactionHash ?? d.eventId,
+          feeAmount,
           timestamp,
         },
       });

--- a/apps/api/src/swaps/swap.types.ts
+++ b/apps/api/src/swaps/swap.types.ts
@@ -10,6 +10,8 @@ export interface SwapSnapshot {
   amount0: string;
   amount1: string;
   priceAtSwap: string;
+  /** Fee charged for this swap (expressed in token0 units). */
+  feeAmount: string;
   txHash: string;
   walletAddress: string;
   timestamp: number;

--- a/apps/api/src/swaps/swaps.repository.ts
+++ b/apps/api/src/swaps/swaps.repository.ts
@@ -80,6 +80,7 @@ export class SwapsRepository {
         amount0: swap.amount0,
         amount1: swap.amount1,
         priceAtSwap,
+        feeAmount: swap.feeAmount,
         txHash: swap.transactionHash,
         walletAddress: swap.senderAddress,
         timestamp: swap.timestamp.getTime(),

--- a/apps/api/src/swaps/swaps.service.ts
+++ b/apps/api/src/swaps/swaps.service.ts
@@ -12,6 +12,8 @@ interface SwapResponse {
   amount0: string;
   amount1: string;
   priceAtSwap: string;
+  /** Fee charged for this swap (expressed in token0 units). */
+  feeAmount: string;
   transactionHash: string;
   walletAddress: string;
   timestamp: number;
@@ -78,6 +80,7 @@ export class SwapsService {
       amount0: swap.amount0,
       amount1: swap.amount1,
       priceAtSwap: swap.priceAtSwap,
+      feeAmount: swap.feeAmount,
       transactionHash: swap.txHash,
       walletAddress: swap.walletAddress,
       timestamp: swap.timestamp,

--- a/prisma/migrations/20260628000000_add_swap_fee_amount/migration.sql
+++ b/prisma/migrations/20260628000000_add_swap_fee_amount/migration.sql
@@ -1,0 +1,2 @@
+-- Add feeAmount column to swap table to store the fee charged per swap
+ALTER TABLE "swap" ADD COLUMN IF NOT EXISTS "feeAmount" TEXT NOT NULL DEFAULT '0';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,8 @@ model Swap {
   sqrtPriceAfter    String
   tickAfter         Int
   transactionHash   String
+  /// Fee amount charged for this swap, derived from amount0 * (feeTier / 1_000_000).
+  feeAmount         String   @default("0")
   timestamp         DateTime @default(now())
 
   // Relations


### PR DESCRIPTION
## Summary

Adds a `feeAmount` field to the `Swap` model so the fee charged for each swap is persisted and returned by the API.

### Changes

- **`prisma/schema.prisma`**: adds `feeAmount String @default("0")` to the `Swap` model.
- **`prisma/migrations/20260628000000_add_swap_fee_amount/migration.sql`**: `ALTER TABLE swap ADD COLUMN feeAmount`.
- **`swap.types.ts`**: adds `feeAmount: string` to `SwapSnapshot`.
- **`swaps.repository.ts`**: reads `swap.feeAmount` and includes it in the snapshot.
- **`swaps.service.ts`**: adds `feeAmount` to `SwapResponse` and `toResponse`.
- **`indexer.worker.ts`** (`projectSwapProcessed`): looks up pool `feeTier` (ppm) and computes `feeAmount = |amount0| × (feeTier / 1_000_000)` before persisting the `Swap` row.

### Validation

- TypeScript: no diagnostics on changed files

Closes #418