### PR TITLE
feat: webhook payload examples, pnpm filter scripts, pre-commit lint,…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# Run ESLint on apps/api before every commit.
+# Fails the commit if lint errors are found.
+pnpm --filter api lint

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -13,6 +13,8 @@ POOL_CONTRACT_ID=
 # Auth
 JWT_SECRET=change-me-in-production
 JWT_EXPIRES_IN=7d
+JWT_ISSUER=swyft-api
+JWT_AUDIENCE=swyft-client
 
 # App
 PORT=3001

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -281,4 +281,80 @@ describe('AuthService', () => {
       jest.restoreAllMocks();
     });
   });
+
+  // ── #412: issuer and audience in issued JWTs ───────────────────────────────
+
+  describe('issueJwt — issuer and audience claims', () => {
+    async function signIn(
+      configOverrides: Record<string, string | undefined>,
+    ) {
+      mockConfigService.get.mockImplementation(
+        (key: string) => configOverrides[key],
+      );
+
+      const nonce = 'iss-aud-nonce';
+      const { walletAddress, signature } = makeSignedNonce(nonce);
+      mockRedis.get.mockResolvedValueOnce(nonce);
+      mockRedis.del.mockResolvedValueOnce(1);
+
+      await service.verifyWallet({ walletAddress, nonce, signature });
+    }
+
+    it('includes issuer in sign options when JWT_ISSUER is configured', async () => {
+      await signIn({
+        JWT_EXPIRES_IN: '15m',
+        JWT_ISSUER: 'swyft-api',
+        JWT_AUDIENCE: undefined,
+      });
+
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ issuer: 'swyft-api' }),
+      );
+    });
+
+    it('includes audience in sign options when JWT_AUDIENCE is configured', async () => {
+      await signIn({
+        JWT_EXPIRES_IN: '15m',
+        JWT_ISSUER: undefined,
+        JWT_AUDIENCE: 'swyft-client',
+      });
+
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ audience: 'swyft-client' }),
+      );
+    });
+
+    it('includes both issuer and audience when both are configured', async () => {
+      await signIn({
+        JWT_EXPIRES_IN: '15m',
+        JWT_ISSUER: 'swyft-api',
+        JWT_AUDIENCE: 'swyft-client',
+      });
+
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          issuer: 'swyft-api',
+          audience: 'swyft-client',
+        }),
+      );
+    });
+
+    it('omits issuer and audience from sign options when neither is configured', async () => {
+      await signIn({
+        JWT_EXPIRES_IN: '15m',
+        JWT_ISSUER: undefined,
+        JWT_AUDIENCE: undefined,
+      });
+
+      const signCallOptions = mockJwtService.sign.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(signCallOptions).not.toHaveProperty('issuer');
+      expect(signCallOptions).not.toHaveProperty('audience');
+    });
+  });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -140,15 +140,20 @@ export class AuthService {
     }
   }
 
-  /** Signs a JWT payload with the configured secret and expiry. */
+  /** Signs a JWT payload with the configured secret, expiry, issuer, and audience. */
   private issueJwt(walletAddress: string): string {
     const payload: JwtPayload = { sub: walletAddress, walletAddress };
 
     // expiresIn is read from JWT_EXPIRES_IN env; falls back to '15m' if unset.
     const expiresIn = this.configService.get<string>('JWT_EXPIRES_IN') ?? '15m';
 
+    const issuer = this.configService.get<string>('JWT_ISSUER');
+    const audience = this.configService.get<string>('JWT_AUDIENCE');
+
     return this.jwtService.sign(payload, {
       expiresIn: expiresIn as `${number}m`,
+      ...(issuer ? { issuer } : {}),
+      ...(audience ? { audience } : {}),
     });
   }
 }

--- a/apps/api/src/auth/jwt-auth.guard.spec.ts
+++ b/apps/api/src/auth/jwt-auth.guard.spec.ts
@@ -1,0 +1,130 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { sign } from 'jsonwebtoken';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+const SECRET = 'test-secret';
+const WALLET = 'GTEST_WALLET_ADDRESS';
+
+function makeContext(token: string | undefined): ExecutionContext {
+  const req: Record<string, unknown> = {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  };
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as unknown as ExecutionContext;
+}
+
+function issueToken(
+  payload: Record<string, unknown>,
+  opts: { issuer?: string; audience?: string; secret?: string } = {},
+) {
+  return sign(payload, opts.secret ?? SECRET, {
+    expiresIn: '1h',
+    ...(opts.issuer ? { issuer: opts.issuer } : {}),
+    ...(opts.audience ? { audience: opts.audience } : {}),
+  });
+}
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    guard = new JwtAuthGuard();
+    process.env = { ...originalEnv, JWT_SECRET: SECRET };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('accepts a valid token without issuer/audience configured', () => {
+    const token = issueToken({ sub: WALLET, walletAddress: WALLET });
+    const ctx = makeContext(token);
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('throws when Authorization header is missing', () => {
+    const ctx = makeContext(undefined);
+    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  });
+
+  // ── Issuer validation ──────────────────────────────────────────────────────
+
+  describe('issuer validation', () => {
+    beforeEach(() => {
+      process.env.JWT_ISSUER = 'swyft-api';
+    });
+
+    it('accepts a token with the correct issuer', () => {
+      const token = issueToken(
+        { sub: WALLET, walletAddress: WALLET },
+        { issuer: 'swyft-api' },
+      );
+      expect(guard.canActivate(makeContext(token))).toBe(true);
+    });
+
+    it('rejects a token with a wrong issuer', () => {
+      const token = issueToken(
+        { sub: WALLET, walletAddress: WALLET },
+        { issuer: 'other-service' },
+      );
+      expect(() => guard.canActivate(makeContext(token))).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rejects a token with no issuer claim when issuer is required', () => {
+      const token = issueToken({ sub: WALLET, walletAddress: WALLET });
+      expect(() => guard.canActivate(makeContext(token))).toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  // ── Audience validation ────────────────────────────────────────────────────
+
+  describe('audience validation', () => {
+    beforeEach(() => {
+      process.env.JWT_AUDIENCE = 'swyft-client';
+    });
+
+    it('accepts a token with the correct audience', () => {
+      const token = issueToken(
+        { sub: WALLET, walletAddress: WALLET },
+        { audience: 'swyft-client' },
+      );
+      expect(guard.canActivate(makeContext(token))).toBe(true);
+    });
+
+    it('rejects a token with a wrong audience', () => {
+      const token = issueToken(
+        { sub: WALLET, walletAddress: WALLET },
+        { audience: 'other-client' },
+      );
+      expect(() => guard.canActivate(makeContext(token))).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rejects a token with no audience claim when audience is required', () => {
+      const token = issueToken({ sub: WALLET, walletAddress: WALLET });
+      expect(() => guard.canActivate(makeContext(token))).toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  // ── Issuer + audience together ─────────────────────────────────────────────
+
+  it('accepts a token that satisfies both issuer and audience', () => {
+    process.env.JWT_ISSUER = 'swyft-api';
+    process.env.JWT_AUDIENCE = 'swyft-client';
+
+    const token = issueToken(
+      { sub: WALLET, walletAddress: WALLET },
+      { issuer: 'swyft-api', audience: 'swyft-client' },
+    );
+    expect(guard.canActivate(makeContext(token))).toBe(true);
+  });
+});

--- a/apps/api/src/auth/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt-auth.guard.ts
@@ -4,13 +4,15 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import { verify } from 'jsonwebtoken';
+import { verify, VerifyOptions } from 'jsonwebtoken';
 
 interface JwtPayload {
   sub?: string;
   walletAddress?: string;
   wallet?: string;
   address?: string;
+  iss?: string;
+  aud?: string | string[];
 }
 
 interface RequestWithUser {
@@ -39,8 +41,16 @@ export class JwtAuthGuard implements CanActivate {
       throw new UnauthorizedException('JWT secret not configured');
     }
 
+    const options: VerifyOptions = {};
+    if (process.env.JWT_ISSUER) {
+      options.issuer = process.env.JWT_ISSUER;
+    }
+    if (process.env.JWT_AUDIENCE) {
+      options.audience = process.env.JWT_AUDIENCE;
+    }
+
     try {
-      const payload = verify(token, secret) as JwtPayload;
+      const payload = verify(token, secret, options) as JwtPayload;
       const walletAddress =
         payload.walletAddress ??
         payload.wallet ??

--- a/apps/api/src/webhooks/webhook.types.ts
+++ b/apps/api/src/webhooks/webhook.types.ts
@@ -13,3 +13,169 @@ export interface WebhookPayload {
   timestamp: string;
   data: Record<string, unknown>;
 }
+
+// ─── Per-event payload shapes ─────────────────────────────────────────────────
+
+/** Emitted when a new concentrated-liquidity pool is deployed on Stellar. */
+export interface PoolCreatedData {
+  poolId: string;
+  token0: string;
+  token1: string;
+  feeBps: number;
+  /** Square-root of the initial price, encoded as a 128-bit fixed-point string. */
+  sqrtPriceX96: string;
+  tick: number;
+}
+
+/** Emitted for every swap executed through a Swyft pool. */
+export interface SwapData {
+  poolId: string;
+  sender: string;
+  recipient: string;
+  amountIn: string;
+  amountOut: string;
+  tokenIn: string;
+  tokenOut: string;
+  priceImpactBps: number;
+  txHash: string;
+}
+
+/** Emitted when a swap exceeds the `largeSwapUsd` threshold on the webhook. */
+export interface SwapLargeData extends SwapData {
+  amountUsd: number;
+}
+
+/** Emitted when a pool's TVL crosses a round-number USD milestone. */
+export interface PoolTvlMilestoneData {
+  poolId: string;
+  token0: string;
+  token1: string;
+  tvlUsd: number;
+  milestone: number;
+}
+
+/** Emitted when a new LP position NFT is minted. */
+export interface PositionMintedData {
+  positionId: string;
+  poolId: string;
+  owner: string;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: string;
+  amount0: string;
+  amount1: string;
+}
+
+/** Emitted when an LP position is fully or partially burned. */
+export interface PositionBurnedData {
+  positionId: string;
+  poolId: string;
+  owner: string;
+  liquidity: string;
+  amount0: string;
+  amount1: string;
+}
+
+/** Maps each event type to its strongly-typed data shape. */
+export interface WebhookEventDataMap {
+  'pool.created': PoolCreatedData;
+  swap: SwapData;
+  'swap.large': SwapLargeData;
+  'pool.tvl.milestone': PoolTvlMilestoneData;
+  'position.minted': PositionMintedData;
+  'position.burned': PositionBurnedData;
+}
+
+/** Typed webhook payload keyed by event. */
+export type TypedWebhookPayload<E extends WebhookEventType> = {
+  event: E;
+  timestamp: string;
+  data: WebhookEventDataMap[E];
+};
+
+// ─── Example payloads (used in docs / tests) ──────────────────────────────────
+
+export const WEBHOOK_PAYLOAD_EXAMPLES: {
+  [E in WebhookEventType]: TypedWebhookPayload<E>;
+} = {
+  'pool.created': {
+    event: 'pool.created',
+    timestamp: '2025-01-15T10:30:00.000Z',
+    data: {
+      poolId: 'pool_GPOOL123',
+      token0: 'XLM',
+      token1: 'USDC',
+      feeBps: 30,
+      sqrtPriceX96: '79228162514264337593543950336',
+      tick: 0,
+    },
+  },
+  swap: {
+    event: 'swap',
+    timestamp: '2025-01-15T10:31:00.000Z',
+    data: {
+      poolId: 'pool_GPOOL123',
+      sender: 'GABC...XYZ',
+      recipient: 'GABC...XYZ',
+      amountIn: '1000000000',
+      amountOut: '99850000',
+      tokenIn: 'XLM',
+      tokenOut: 'USDC',
+      priceImpactBps: 5,
+      txHash: 'abc123def456',
+    },
+  },
+  'swap.large': {
+    event: 'swap.large',
+    timestamp: '2025-01-15T10:32:00.000Z',
+    data: {
+      poolId: 'pool_GPOOL123',
+      sender: 'GABC...XYZ',
+      recipient: 'GABC...XYZ',
+      amountIn: '50000000000',
+      amountOut: '4990000000',
+      tokenIn: 'XLM',
+      tokenOut: 'USDC',
+      priceImpactBps: 42,
+      txHash: 'def789ghi012',
+      amountUsd: 15000,
+    },
+  },
+  'pool.tvl.milestone': {
+    event: 'pool.tvl.milestone',
+    timestamp: '2025-01-15T10:33:00.000Z',
+    data: {
+      poolId: 'pool_GPOOL123',
+      token0: 'XLM',
+      token1: 'USDC',
+      tvlUsd: 1000000,
+      milestone: 1000000,
+    },
+  },
+  'position.minted': {
+    event: 'position.minted',
+    timestamp: '2025-01-15T10:34:00.000Z',
+    data: {
+      positionId: 'pos_GPOS456',
+      poolId: 'pool_GPOOL123',
+      owner: 'GABC...XYZ',
+      tickLower: -100,
+      tickUpper: 100,
+      liquidity: '1000000000000',
+      amount0: '500000000',
+      amount1: '499000000',
+    },
+  },
+  'position.burned': {
+    event: 'position.burned',
+    timestamp: '2025-01-15T10:35:00.000Z',
+    data: {
+      positionId: 'pos_GPOS456',
+      poolId: 'pool_GPOOL123',
+      owner: 'GABC...XYZ',
+      liquidity: '1000000000000',
+      amount0: '502000000',
+      amount1: '497500000',
+    },
+  },
+};

--- a/apps/api/src/webhooks/webhooks.controller.spec.ts
+++ b/apps/api/src/webhooks/webhooks.controller.spec.ts
@@ -1,7 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksService } from './webhooks.service';
-import { WebhookEventType } from './webhook.types';
+import {
+  WebhookEventType,
+  WEBHOOK_EVENTS,
+  WEBHOOK_PAYLOAD_EXAMPLES,
+} from './webhook.types';
 
 const mockService = {
   create: jest.fn().mockResolvedValue({
@@ -75,5 +79,30 @@ describe('WebhooksController', () => {
       'wh-1',
       'GTEST_WALLET_ADDRESS',
     );
+  });
+
+  // ── #409: payload examples ─────────────────────────────────────────────────
+
+  describe('eventExamples', () => {
+    it('returns examples for every webhook event type', () => {
+      const examples = controller.eventExamples();
+      for (const event of WEBHOOK_EVENTS) {
+        expect(examples).toHaveProperty(event);
+      }
+    });
+
+    it('returns the canonical WEBHOOK_PAYLOAD_EXAMPLES object', () => {
+      expect(controller.eventExamples()).toBe(WEBHOOK_PAYLOAD_EXAMPLES);
+    });
+
+    it('each example has event, timestamp, and data fields', () => {
+      const examples = controller.eventExamples();
+      for (const event of WEBHOOK_EVENTS) {
+        const ex = examples[event];
+        expect(ex.event).toBe(event);
+        expect(typeof ex.timestamp).toBe('string');
+        expect(ex.data).toBeDefined();
+      }
+    });
   });
 });

--- a/apps/api/src/webhooks/webhooks.controller.ts
+++ b/apps/api/src/webhooks/webhooks.controller.ts
@@ -8,10 +8,15 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { WebhooksService } from './webhooks.service';
-import { WebhookEventType } from './webhook.types';
+import { WebhookEventType, WEBHOOK_PAYLOAD_EXAMPLES } from './webhook.types';
 import { SWAGGER_TAGS } from '../swagger.constants';
 
 interface AuthRequest {
@@ -41,6 +46,32 @@ export class WebhooksController {
    */
   @Post()
   @ApiOperation({ summary: 'Register a webhook' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['url', 'eventTypes'],
+      properties: {
+        url: { type: 'string', example: 'https://example.com/webhook' },
+        eventTypes: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'pool.created',
+              'swap',
+              'swap.large',
+              'pool.tvl.milestone',
+              'position.minted',
+              'position.burned',
+            ],
+          },
+          example: ['swap', 'swap.large'],
+        },
+        secret: { type: 'string', example: 'my-hmac-secret' },
+        largeSwapUsd: { type: 'number', example: 10000 },
+      },
+    },
+  })
   create(
     @Request() req: AuthRequest,
     @Body()
@@ -74,6 +105,20 @@ export class WebhooksController {
   async list(@Request() req: AuthRequest): Promise<WebhookListResponse> {
     const items = await this.service.list(req.user.walletAddress);
     return { loading: false, items };
+  }
+
+  /**
+   * Return example payloads for all webhook event types.
+   * Useful for documentation and client integration.
+   *
+   * @returns Map of event type → example payload.
+   */
+  @Get('event-examples')
+  @ApiOperation({
+    summary: 'Return example payloads for all webhook event types',
+  })
+  eventExamples() {
+    return WEBHOOK_PAYLOAD_EXAMPLES;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -8,9 +8,19 @@
     "test": "turbo run test",
     "validate:contracts": "node scripts/validate-contracts.js",
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
-    "db:generate": "prisma generate --schema=prisma/schema.prisma"
+    "db:generate": "prisma generate --schema=prisma/schema.prisma",
+    "prepare": "husky",
+    "api:dev": "pnpm --filter api dev",
+    "api:build": "pnpm --filter api build",
+    "api:test": "pnpm --filter api test",
+    "api:lint": "pnpm --filter api lint",
+    "web:dev": "pnpm --filter web dev",
+    "web:build": "pnpm --filter web build",
+    "web:test": "pnpm --filter web test",
+    "web:lint": "pnpm --filter web lint"
   },
   "devDependencies": {
+    "husky": "^9.0.0",
     "turbo": "^2.0.0",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0",


### PR DESCRIPTION
… JWT iss/aud validation

Closes #409 : add typed payload interfaces + WEBHOOK_PAYLOAD_EXAMPLES, GET /webhooks/event-examples endpoint
Closes #410 : add api:* and web:* pnpm filter scripts to root package.json
Closes #411 : add .husky/pre-commit running pnpm --filter api lint
Closes  #412 : validate JWT issuer and audience in JwtAuthGuard and issueJwt

## Summary

<!-- What does this PR do? -->

## Related issue

- Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed
