### PR TITLE
feat(candles): support 1d interval in aggregator

### DIFF
--- a/apps/api/src/candles/candles.service.spec.ts
+++ b/apps/api/src/candles/candles.service.spec.ts
@@ -1,0 +1,102 @@
+import { CandlesService } from './candles.service';
+
+// ---------------------------------------------------------------------------
+// Minimal PrismaService stub — only the methods exercised by CandlesService.
+// ---------------------------------------------------------------------------
+function makePrismaStub(swaps: any[] = []) {
+  return {
+    swapProcessed: {
+      findMany: jest.fn().mockResolvedValue(swaps),
+    },
+    priceCandle: {
+      upsert: jest.fn().mockResolvedValue({}),
+    },
+  } as any;
+}
+
+describe('CandlesService', () => {
+  describe('aggregate()', () => {
+    it('does nothing when there are no swaps for the period', async () => {
+      const prisma = makePrismaStub([]);
+      const service = new CandlesService(prisma);
+
+      await service.aggregate('1d');
+
+      expect(prisma.priceCandle.upsert).not.toHaveBeenCalled();
+    });
+
+    it('writes a 1d candle with correct OHLCV for a single pool', async () => {
+      const swaps = [
+        { poolId: 'pool-1', sqrtPriceX96: '100', amount0: '500', createdAt: new Date() },
+        { poolId: 'pool-1', sqrtPriceX96: '120', amount0: '-300', createdAt: new Date() },
+        { poolId: 'pool-1', sqrtPriceX96: '90',  amount0: '200', createdAt: new Date() },
+      ];
+      const prisma = makePrismaStub(swaps);
+      const service = new CandlesService(prisma);
+
+      await service.aggregate('1d');
+
+      expect(prisma.priceCandle.upsert).toHaveBeenCalledTimes(1);
+
+      const { create } = prisma.priceCandle.upsert.mock.calls[0][0];
+      expect(create.poolId).toBe('pool-1');
+      expect(create.interval).toBe('1d');
+      expect(create.open).toBe(100);     // first sqrtPriceX96
+      expect(create.close).toBe(90);    // last  sqrtPriceX96
+      expect(create.high).toBe(120);
+      expect(create.low).toBe(90);
+      // volumeUsd = sum of |amount0| = 500 + 300 + 200 = 1000
+      expect(create.volumeUsd).toBe(1000);
+    });
+
+    it('writes separate candles for distinct pools', async () => {
+      const swaps = [
+        { poolId: 'pool-A', sqrtPriceX96: '200', amount0: '100', createdAt: new Date() },
+        { poolId: 'pool-B', sqrtPriceX96: '50',  amount0: '400', createdAt: new Date() },
+      ];
+      const prisma = makePrismaStub(swaps);
+      const service = new CandlesService(prisma);
+
+      await service.aggregate('1d');
+
+      expect(prisma.priceCandle.upsert).toHaveBeenCalledTimes(2);
+
+      const poolIds = prisma.priceCandle.upsert.mock.calls.map(
+        (c: any[]) => c[0].create.poolId,
+      );
+      expect(poolIds).toContain('pool-A');
+      expect(poolIds).toContain('pool-B');
+    });
+
+    it('queries swaps within the previous 1d window', async () => {
+      const prisma = makePrismaStub([]);
+      const service = new CandlesService(prisma);
+      const before = Date.now();
+
+      await service.aggregate('1d');
+
+      const after = Date.now();
+      const { where } = prisma.swapProcessed.findMany.mock.calls[0][0];
+
+      // periodEnd should be at most `now` rounded to the day boundary
+      const periodEnd: Date = where.createdAt.lt;
+      const periodStart: Date = where.createdAt.gte;
+
+      const windowMs = periodEnd.getTime() - periodStart.getTime();
+      expect(windowMs).toBe(86_400_000); // exactly one day
+
+      // The period must lie entirely within [before - 2d, after]
+      expect(periodStart.getTime()).toBeGreaterThanOrEqual(before - 2 * 86_400_000);
+      expect(periodEnd.getTime()).toBeLessThanOrEqual(after + 1000);
+    });
+
+    it('supports all defined intervals without throwing', async () => {
+      const intervals: Array<'1m' | '5m' | '1h' | '1d'> = ['1m', '5m', '1h', '1d'];
+      for (const interval of intervals) {
+        const prisma = makePrismaStub([]);
+        const service = new CandlesService(prisma);
+        await expect(service.aggregate(interval)).resolves.toBeUndefined();
+      }
+    });
+  });
+});

--- a/apps/api/src/candles/candles.service.ts
+++ b/apps/api/src/candles/candles.service.ts
@@ -7,6 +7,11 @@ const INTERVAL_MS: Record<CandleInterval, number> = {
   '1m': 60_000,
   '5m': 300_000,
   '1h': 3_600_000,
+  /**
+   * 1-day candle: covers the UTC-midnight-to-midnight window of the previous
+   * calendar day. The BullMQ cron `0 0 * * *` fires at UTC midnight so the
+   * period calculation always resolves to yesterday's window.
+   */
   '1d': 86_400_000,
 };
 


### PR DESCRIPTION
## Summary

Formalises and tests the `1d` candle interval in the aggregator pipeline.

### What was already in place

| Location | Status |
|---|---|
| `CandleInterval` type | ✅ `'1d'` present |
| `INTERVAL_MS['1d']` | ✅ `86_400_000` |
| `SCHEDULES` cron `'0 0 * * *'` | ✅ present |
| `VALID_INTERVALS` in price controller | ✅ `'1d'` included |
| `getIntervalSeconds / getDefaultIntervalSeconds` | ✅ handled |

### What this PR adds

- **JSDoc comment** on the `'1d'` entry in `INTERVAL_MS` documenting the UTC midnight-boundary semantics and the relationship between the cron fire time and the period-window calculation.
- **`candles.service.spec.ts`** — unit tests covering:
  - No-op when no swaps exist in the period
  - Correct OHLCV values (open/high/low/close/volumeUsd) computed from a set of swaps
  - Separate candle rows written per distinct pool
  - The query window for `1d` is exactly `86_400_000 ms`
  - All four intervals (`1m`, `5m`, `1h`, `1d`) resolve without error

### Validation

- TypeScript: no diagnostics on changed files
- Tests require Jest (not installed in CI yet); test runner is the standard NestJS/Jest config already present in `package.json`

Closes #420