### PR TITLE
Fix/price candles webhook dispatch readme env

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ swyft/
 
 ```bash
 # Clone the repo
-git clone https://github.com/Valreb001/Swyft.git
+git clone https://github.com/vatix-protocol/Swyft.git
 cd swyft
 
 # Install all dependencies
@@ -163,7 +163,7 @@ Swyft is built almost entirely by external contributors. The maintainer handles 
 
 ### Good first issues
 
-Look for issues labelled [`good first issue`](https://github.com/Valreb001/Swyft/issues?q=label%3A%22good+first+issue%22). These are small, well-scoped tasks that don't require deep protocol knowledge.
+Look for issues labelled [`good first issue`](https://github.com/vatix-protocol/Swyft/issues?q=label%3A%22good+first+issue%22). These are small, well-scoped tasks that don't require deep protocol knowledge.
 
 ### Issue labels
 

--- a/apps/api/src/price/price.controller.spec.ts
+++ b/apps/api/src/price/price.controller.spec.ts
@@ -16,12 +16,12 @@ const mockSpotResponse: SpotPriceResponse = {
 };
 
 const mockCandle: PriceCandle = {
-  timestamp: 1700000000,
-  open: '0.09',
-  high: '0.11',
-  low: '0.08',
-  close: '0.10',
-  volume: '50000',
+  time: 1700000000,
+  open: 0.09,
+  high: 0.11,
+  low: 0.08,
+  close: 0.1,
+  volume: 50000,
 };
 
 describe('PriceController', () => {

--- a/apps/api/src/webhooks/webhook.processor.spec.ts
+++ b/apps/api/src/webhooks/webhook.processor.spec.ts
@@ -1,0 +1,263 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookWorker, WebhookJob, WEBHOOK_QUEUE } from './webhook.processor';
+import { PrismaService } from '../prisma/prisma.service';
+import { WebhookPayload } from './webhook.types';
+import { Job } from 'bullmq';
+
+// ── Mock factories ────────────────────────────────────────────────────────────
+
+function buildMockPrisma() {
+  return {
+    webhook: {
+      findUnique: jest.fn(),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    webhookDelivery: {
+      create: jest.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+function buildMockQueue() {
+  return {
+    add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const baseWebhook = {
+  id: 'wh-1',
+  url: 'https://example.com/hook',
+  secret: null as string | null,
+  disabled: false,
+  consecutiveFails: 0,
+};
+
+const basePayload: WebhookPayload = {
+  event: 'pool.created',
+  timestamp: '2025-01-15T10:30:00.000Z',
+  data: { poolId: 'pool-1', token0: 'XLM', token1: 'USDC' },
+};
+
+function makeJob(data: WebhookJob): Job<WebhookJob> {
+  return { data } as Job<WebhookJob>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+let fetchSpy: jest.SpyInstance;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('WebhookWorker (dispatch integration)', () => {
+  let worker: WebhookWorker;
+  let prisma: ReturnType<typeof buildMockPrisma>;
+
+  beforeEach(async () => {
+    prisma = buildMockPrisma();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookWorker,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    worker = module.get<WebhookWorker>(WebhookWorker);
+
+    // Stub the BullMQ queue so no real Redis connection is opened
+    (worker as any).queue = buildMockQueue();
+
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ status: 200 } as Response);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+  });
+
+  // ── dispatch (queue integration) ──────────────────────────────────────────
+
+  describe('dispatch()', () => {
+    it('enqueues a deliver job with the correct webhook id and payload', async () => {
+      await worker.dispatch('wh-1', basePayload);
+
+      expect((worker as any).queue.add).toHaveBeenCalledWith(
+        'deliver',
+        { webhookId: 'wh-1', payload: basePayload },
+        expect.objectContaining({ attempts: 3 }),
+      );
+    });
+
+    it('uses exponential back-off for retries', async () => {
+      await worker.dispatch('wh-1', basePayload);
+
+      const [, , opts] = (worker as any).queue.add.mock.calls[0];
+      expect(opts.backoff).toEqual({ type: 'exponential', delay: 2000 });
+    });
+
+    it('resolves without throwing on successful enqueue', async () => {
+      await expect(worker.dispatch('wh-1', basePayload)).resolves.toBeUndefined();
+    });
+
+    it('propagates errors when the queue rejects', async () => {
+      (worker as any).queue.add.mockRejectedValue(new Error('queue full'));
+
+      await expect(worker.dispatch('wh-1', basePayload)).rejects.toThrow(
+        'queue full',
+      );
+    });
+  });
+
+  // ── deliver (processor integration) ───────────────────────────────────────
+
+  describe('deliver()', () => {
+    const deliver = (data: WebhookJob) =>
+      (worker as any).deliver(makeJob(data));
+
+    it('skips delivery when the webhook record is not found', async () => {
+      prisma.webhook.findUnique.mockResolvedValue(null);
+
+      await deliver({ webhookId: 'wh-missing', payload: basePayload });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips delivery when the webhook is disabled', async () => {
+      prisma.webhook.findUnique.mockResolvedValue({
+        ...baseWebhook,
+        disabled: true,
+      });
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('POSTs the JSON payload to the webhook URL', async () => {
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        baseWebhook.url,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(basePayload),
+        }),
+      );
+    });
+
+    it('includes Content-Type: application/json header', async () => {
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('attaches X-Swyft-Signature when webhook has a secret', async () => {
+      prisma.webhook.findUnique.mockResolvedValue({
+        ...baseWebhook,
+        secret: 'hmac-secret',
+      });
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['X-Swyft-Signature']).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('omits X-Swyft-Signature when webhook has no secret', async () => {
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['X-Swyft-Signature']).toBeUndefined();
+    });
+
+    it('records a delivery log entry after each attempt', async () => {
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      expect(prisma.webhookDelivery.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          webhookId: 'wh-1',
+          eventType: basePayload.event,
+          responseStatus: 200,
+        }),
+      });
+    });
+
+    it('resets consecutiveFails to 0 on success', async () => {
+      prisma.webhook.findUnique.mockResolvedValue({
+        ...baseWebhook,
+        consecutiveFails: 3,
+      });
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      expect(prisma.webhook.update).toHaveBeenCalledWith({
+        where: { id: 'wh-1' },
+        data: { consecutiveFails: 0 },
+      });
+    });
+
+    it('increments consecutiveFails on HTTP 4xx response', async () => {
+      fetchSpy.mockResolvedValue({ status: 500 } as Response);
+      prisma.webhook.findUnique.mockResolvedValue({
+        ...baseWebhook,
+        consecutiveFails: 2,
+      });
+
+      await expect(
+        deliver({ webhookId: 'wh-1', payload: basePayload }),
+      ).rejects.toThrow(/Delivery failed/);
+
+      expect(prisma.webhook.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ consecutiveFails: 3 }),
+        }),
+      );
+    });
+
+    it('disables the webhook after 10 consecutive failures', async () => {
+      fetchSpy.mockResolvedValue({ status: 503 } as Response);
+      prisma.webhook.findUnique.mockResolvedValue({
+        ...baseWebhook,
+        consecutiveFails: 9,
+      });
+
+      await expect(
+        deliver({ webhookId: 'wh-1', payload: basePayload }),
+      ).rejects.toThrow();
+
+      expect(prisma.webhook.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ disabled: true }),
+        }),
+      );
+    });
+
+    it('handles network errors gracefully and records undefined status', async () => {
+      fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await expect(
+        deliver({ webhookId: 'wh-1', payload: basePayload }),
+      ).rejects.toThrow(/Delivery failed/);
+
+      expect(prisma.webhookDelivery.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          responseStatus: undefined,
+        }),
+      });
+    });
+  });
+});

--- a/apps/api/src/webhooks/webhook.processor.spec.ts
+++ b/apps/api/src/webhooks/webhook.processor.spec.ts
@@ -1,5 +1,4 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { WebhookWorker, WebhookJob, WEBHOOK_QUEUE } from './webhook.processor';
+import { WebhookWorker, WebhookJob } from './webhook.processor';
 import { PrismaService } from '../prisma/prisma.service';
 import { WebhookPayload } from './webhook.types';
 import { Job } from 'bullmq';
@@ -45,29 +44,18 @@ function makeJob(data: WebhookJob): Job<WebhookJob> {
   return { data } as Job<WebhookJob>;
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-let fetchSpy: jest.SpyInstance;
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('WebhookWorker (dispatch integration)', () => {
   let worker: WebhookWorker;
   let prisma: ReturnType<typeof buildMockPrisma>;
+  let fetchSpy: jest.SpyInstance;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     prisma = buildMockPrisma();
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        WebhookWorker,
-        { provide: PrismaService, useValue: prisma },
-      ],
-    }).compile();
-
-    worker = module.get<WebhookWorker>(WebhookWorker);
-
-    // Stub the BullMQ queue so no real Redis connection is opened
+    // Instantiate directly to skip onModuleInit (avoids real Redis/BullMQ Worker)
+    worker = new WebhookWorker(prisma as unknown as PrismaService);
     (worker as any).queue = buildMockQueue();
 
     fetchSpy = jest
@@ -75,7 +63,7 @@ describe('WebhookWorker (dispatch integration)', () => {
       .mockResolvedValue({ status: 200 } as Response);
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     jest.restoreAllMocks();
   });
 
@@ -100,7 +88,9 @@ describe('WebhookWorker (dispatch integration)', () => {
     });
 
     it('resolves without throwing on successful enqueue', async () => {
-      await expect(worker.dispatch('wh-1', basePayload)).resolves.toBeUndefined();
+      await expect(
+        worker.dispatch('wh-1', basePayload),
+      ).resolves.toBeUndefined();
     });
 
     it('propagates errors when the queue rejects', async () => {
@@ -156,8 +146,10 @@ describe('WebhookWorker (dispatch integration)', () => {
 
       await deliver({ webhookId: 'wh-1', payload: basePayload });
 
-      const [, init] = fetchSpy.mock.calls[0];
-      expect(init.headers['Content-Type']).toBe('application/json');
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+        'application/json',
+      );
     });
 
     it('attaches X-Swyft-Signature when webhook has a secret', async () => {
@@ -168,8 +160,10 @@ describe('WebhookWorker (dispatch integration)', () => {
 
       await deliver({ webhookId: 'wh-1', payload: basePayload });
 
-      const [, init] = fetchSpy.mock.calls[0];
-      expect(init.headers['X-Swyft-Signature']).toMatch(/^[0-9a-f]{64}$/);
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(
+        (init.headers as Record<string, string>)['X-Swyft-Signature'],
+      ).toMatch(/^[0-9a-f]{64}$/);
     });
 
     it('omits X-Swyft-Signature when webhook has no secret', async () => {
@@ -177,8 +171,10 @@ describe('WebhookWorker (dispatch integration)', () => {
 
       await deliver({ webhookId: 'wh-1', payload: basePayload });
 
-      const [, init] = fetchSpy.mock.calls[0];
-      expect(init.headers['X-Swyft-Signature']).toBeUndefined();
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(
+        (init.headers as Record<string, string>)['X-Swyft-Signature'],
+      ).toBeUndefined();
     });
 
     it('records a delivery log entry after each attempt', async () => {
@@ -209,7 +205,7 @@ describe('WebhookWorker (dispatch integration)', () => {
       });
     });
 
-    it('increments consecutiveFails on HTTP 4xx response', async () => {
+    it('increments consecutiveFails on HTTP 5xx response', async () => {
       fetchSpy.mockResolvedValue({ status: 500 } as Response);
       prisma.webhook.findUnique.mockResolvedValue({
         ...baseWebhook,

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,5 @@
 # "TESTNET" or "PUBLIC"
 NEXT_PUBLIC_STELLAR_NETWORK=TESTNET
+
+# Soroban RPC endpoint (used by @swyft/sdk in the browser)
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Related issue

Closes #365 
closes #366 
closes #367 
closes #368
FILES CHANGED:
- apps/api/src/price/price.controller.spec.ts
- apps/api/src/webhooks/webhook.processor.spec.ts (new)
- README.md
- apps/web/.env.example

---
What was implemented:

1. Price controller spec against real candles (price.controller.spec.ts): The mockCandle fixture was misaligned with the actual PriceCandle interface exported by price.service.ts. It used timestamp (wrong field name) and string OHLCV values — but the real interface uses time: number and numeric open/high/low/close/volume. Fixed to match exactly: { time: 1700000000, open: 0.09, high: 0.11, low: 0.08, close: 0.1, volume: 50000 }.

2. Webhooks dispatch integration test (webhook.processor.spec.ts): Created a new spec covering the full WebhookWorker dispatch pipeline — both the queue-enqueue layer (dispatch()) and the HTTP-delivery layer (deliver()). Tests cover: correct job options (3 attempts, exponential backoff), HMAC-SHA256 signature attachment when a secret is set, delivery log recording, consecutiveFails increment/reset logic, auto-disable after 10 consecutive failures, and graceful handling of network errors (ECONNREFUSED → undefined status). Worker is instantiated directly (bypassing onModuleInit) to avoid real Redis/BullMQ connections in CI.

3. Fix README org links to vatix-protocol (README.md): Two GitHub URLs in the README pointed at the old Valreb001 org. Both updated to vatix-protocol: the git clone command and the "good first issue" label filter link.

4. Add STELLAR_RPC_URL to web .env.example (apps/web/.env.example): The API's .env.example already had STELLAR_RPC_URL, but the web app's .env.example was missing it. Added NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org so the SDK can reach Soroban RPC directly from the browser.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed
