### PR TITLE
feat(api): tvl tie-break, 1h candles from 5m buckets, candle backfill…

### DIFF
--- a/apps/api/src/candles/candles.processor.ts
+++ b/apps/api/src/candles/candles.processor.ts
@@ -63,6 +63,11 @@ export class CandlesWorker implements OnModuleInit, OnModuleDestroy {
       existing.map((j) => this.queue.removeRepeatableByKey(j.key)),
     );
 
+    // Backfill in schedule order so 1h candles have their 5m buckets ready.
+    for (const { interval } of SCHEDULES) {
+      await this.service.backfill(interval);
+    }
+
     for (const { interval, cron } of SCHEDULES) {
       await this.queue.add(
         interval,

--- a/apps/api/src/candles/candles.service.spec.ts
+++ b/apps/api/src/candles/candles.service.spec.ts
@@ -1,0 +1,103 @@
+import { CandlesService } from './candles.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+function makeSwap(poolId: string, createdAt: Date, sqrtPriceX96: string, amount0: string) {
+  return { poolId, createdAt, sqrtPriceX96, amount0 } as never;
+}
+
+function makeBucket(
+  poolId: string,
+  periodStart: Date,
+  open: number,
+  high: number,
+  low: number,
+  close: number,
+  volumeUsd: number,
+) {
+  return { poolId, periodStart, open, high, low, close, volumeUsd } as never;
+}
+
+describe('CandlesService', () => {
+  let prisma: {
+    swapProcessed: { findMany: jest.Mock; findFirst: jest.Mock };
+    priceCandle: { findMany: jest.Mock; upsert: jest.Mock };
+  };
+  let service: CandlesService;
+
+  beforeEach(() => {
+    prisma = {
+      swapProcessed: { findMany: jest.fn(), findFirst: jest.fn() },
+      priceCandle: { findMany: jest.fn(), upsert: jest.fn() },
+    };
+    service = new CandlesService(prisma as unknown as PrismaService);
+  });
+
+  it('aggregates a 5m candle directly from raw swaps', async () => {
+    prisma.swapProcessed.findMany.mockResolvedValue([
+      makeSwap('pool-1', new Date(0), '100', '-5'),
+      makeSwap('pool-1', new Date(1000), '120', '3'),
+    ]);
+
+    await service.aggregate('5m');
+
+    expect(prisma.swapProcessed.findMany).toHaveBeenCalled();
+    expect(prisma.priceCandle.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          poolId: 'pool-1',
+          open: 100,
+          high: 120,
+          low: 100,
+          close: 120,
+          volumeUsd: 8,
+        }),
+      }),
+    );
+  });
+
+  it('aggregates a 1h candle from existing 5m buckets instead of raw swaps', async () => {
+    prisma.priceCandle.findMany.mockResolvedValue([
+      makeBucket('pool-1', new Date(0), 10, 15, 9, 12, 100),
+      makeBucket('pool-1', new Date(300_000), 12, 18, 11, 16, 50),
+    ]);
+
+    await service.aggregate('1h');
+
+    expect(prisma.swapProcessed.findMany).not.toHaveBeenCalled();
+    expect(prisma.priceCandle.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ interval: '5m' }) }),
+    );
+    expect(prisma.priceCandle.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          poolId: 'pool-1',
+          open: 10,
+          high: 18,
+          low: 9,
+          close: 16,
+          volumeUsd: 150,
+        }),
+      }),
+    );
+  });
+
+  it('backfills every missing period since the first recorded swap', async () => {
+    prisma.swapProcessed.findFirst.mockResolvedValue({
+      createdAt: new Date(Date.now() - 3 * 60_000),
+    });
+    prisma.swapProcessed.findMany.mockResolvedValue([]);
+
+    await service.backfill('1m');
+
+    // ~3 missing 1-minute periods since the first swap.
+    expect(prisma.swapProcessed.findMany.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does nothing when there are no recorded swaps to backfill from', async () => {
+    prisma.swapProcessed.findFirst.mockResolvedValue(null);
+
+    await service.backfill('1h');
+
+    expect(prisma.priceCandle.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/candles/candles.service.ts
+++ b/apps/api/src/candles/candles.service.ts
@@ -10,6 +10,20 @@ const INTERVAL_MS: Record<CandleInterval, number> = {
   '1d': 86_400_000,
 };
 
+// 1h candles are derived from already-aggregated 5m buckets instead of
+// re-scanning raw swaps, so they stay consistent with the 5m series.
+const BUCKET_SOURCE: Partial<Record<CandleInterval, CandleInterval>> = {
+  '1h': '5m',
+};
+
+interface Ohlcv {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volumeUsd: number;
+}
+
 @Injectable()
 export class CandlesService {
   private readonly logger = new Logger(CandlesService.name);
@@ -18,43 +32,67 @@ export class CandlesService {
 
   async aggregate(interval: CandleInterval): Promise<void> {
     const ms = INTERVAL_MS[interval];
-    const now = Date.now();
-    const periodStart = new Date(Math.floor((now - ms) / ms) * ms);
-    const periodEnd = new Date(periodStart.getTime() + ms);
+    const periodStart = new Date(Math.floor((Date.now() - ms) / ms) * ms);
+    const written = await this.aggregatePeriod(interval, periodStart);
+    this.logger.log(
+      `[${interval}] Wrote ${written} candle(s) for period ${periodStart.toISOString()}`,
+    );
+  }
 
-    const swaps = await this.prisma.swapProcessed.findMany({
-      where: { createdAt: { gte: periodStart, lt: periodEnd } },
+  /** Fills in every candle of `interval` missing since the first recorded swap. */
+  async backfill(interval: CandleInterval): Promise<void> {
+    const firstSwap = await this.prisma.swapProcessed.findFirst({
       orderBy: { createdAt: 'asc' },
     });
+    if (!firstSwap) return;
 
-    if (!swaps.length) return;
-
-    const byPool = new Map<string, typeof swaps>();
-    for (const swap of swaps) {
-      const list = byPool.get(swap.poolId) ?? [];
-      list.push(swap);
-      byPool.set(swap.poolId, list);
-    }
+    const ms = INTERVAL_MS[interval];
+    let periodStart = new Date(
+      Math.floor(firstSwap.createdAt.getTime() / ms) * ms,
+    );
+    const lastPeriodStart = new Date(Math.floor((Date.now() - ms) / ms) * ms);
 
     let written = 0;
-    for (const [poolId, poolSwaps] of byPool) {
-      const prices = poolSwaps.map((s) => Number(s.sqrtPriceX96));
-      const volumeUsd = poolSwaps.reduce(
-        (sum, s) => sum + Math.abs(Number(s.amount0)),
-        0,
-      );
+    while (periodStart < lastPeriodStart) {
+      written += await this.aggregatePeriod(interval, periodStart);
+      periodStart = new Date(periodStart.getTime() + ms);
+    }
+    this.logger.log(`[${interval}] Backfilled ${written} candle(s)`);
+  }
 
-      const candle = {
-        poolId,
-        interval,
-        periodStart,
-        open: prices[0],
-        high: Math.max(...prices),
-        low: Math.min(...prices),
-        close: prices[prices.length - 1],
-        volumeUsd,
-      };
+  private async aggregatePeriod(
+    interval: CandleInterval,
+    periodStart: Date,
+  ): Promise<number> {
+    const periodEnd = new Date(periodStart.getTime() + INTERVAL_MS[interval]);
+    const sourceInterval = BUCKET_SOURCE[interval];
+    const byPool = new Map<string, Ohlcv>();
 
+    if (sourceInterval) {
+      const buckets = await this.prisma.priceCandle.findMany({
+        where: {
+          interval: sourceInterval,
+          periodStart: { gte: periodStart, lt: periodEnd },
+        },
+        orderBy: { periodStart: 'asc' },
+      });
+      for (const b of buckets) {
+        this.accumulate(byPool, b.poolId, b.open, b.high, b.low, b.close, b.volumeUsd);
+      }
+    } else {
+      const swaps = await this.prisma.swapProcessed.findMany({
+        where: { createdAt: { gte: periodStart, lt: periodEnd } },
+        orderBy: { createdAt: 'asc' },
+      });
+      for (const s of swaps) {
+        const price = Number(s.sqrtPriceX96);
+        const volume = Math.abs(Number(s.amount0));
+        this.accumulate(byPool, s.poolId, price, price, price, price, volume);
+      }
+    }
+
+    for (const [poolId, ohlcv] of byPool) {
+      const candle = { poolId, interval, periodStart, ...ohlcv };
       await this.prisma.priceCandle.upsert({
         where: {
           poolId_interval_periodStart: { poolId, interval, periodStart },
@@ -62,11 +100,29 @@ export class CandlesService {
         create: candle,
         update: candle,
       });
-      written++;
     }
 
-    this.logger.log(
-      `[${interval}] Wrote ${written} candles for period ${periodStart.toISOString()}`,
-    );
+    return byPool.size;
+  }
+
+  /** Folds one more open/high/low/close/volume sample into the running candle for a pool. */
+  private accumulate(
+    byPool: Map<string, Ohlcv>,
+    poolId: string,
+    open: number,
+    high: number,
+    low: number,
+    close: number,
+    volumeUsd: number,
+  ): void {
+    const existing = byPool.get(poolId);
+    if (!existing) {
+      byPool.set(poolId, { open, high, low, close, volumeUsd });
+      return;
+    }
+    existing.high = Math.max(existing.high, high);
+    existing.low = Math.min(existing.low, low);
+    existing.close = close;
+    existing.volumeUsd += volumeUsd;
   }
 }

--- a/apps/api/src/pools/pools.repository.spec.ts
+++ b/apps/api/src/pools/pools.repository.spec.ts
@@ -62,6 +62,21 @@ describe('PoolsRepository', () => {
     expect(prisma.pool.findMany).toHaveBeenCalledWith({ where: undefined });
   });
 
+  it('breaks ties on equal tvl deterministically by id', async () => {
+    prisma.pool.findMany.mockResolvedValue([
+      makePool({ id: 'pool-b', tvl: '100' }),
+      makePool({ id: 'pool-a', tvl: '100' }),
+    ]);
+
+    const result = await repository.listActivePools({
+      page: 1,
+      limit: 10,
+      orderBy: 'tvl',
+    });
+
+    expect(result.items.map((p) => p.id)).toEqual(['pool-a', 'pool-b']);
+  });
+
   it('uses a case-insensitive database search for token addresses', async () => {
     prisma.pool.findMany.mockResolvedValue([]);
 

--- a/apps/api/src/pools/pools.repository.ts
+++ b/apps/api/src/pools/pools.repository.ts
@@ -34,9 +34,14 @@ export class PoolsRepository {
     });
     const snapshots = pools.map((pool) => this.toSnapshot(pool));
     const sorted = snapshots.sort((a, b) => {
-      if (query.orderBy === 'volume') return b.volume24h - a.volume24h;
-      if (query.orderBy === 'apr') return b.feeApr - a.feeApr;
-      return b.tvl - a.tvl;
+      const primary =
+        query.orderBy === 'volume'
+          ? b.volume24h - a.volume24h
+          : query.orderBy === 'apr'
+            ? b.feeApr - a.feeApr
+            : b.tvl - a.tvl;
+      // Tie-break deterministically so pagination is stable across requests.
+      return primary !== 0 ? primary : a.id.localeCompare(b.id);
     });
 
     const offset = (query.page - 1) * query.limit;

--- a/apps/api/src/search/search.service.spec.ts
+++ b/apps/api/src/search/search.service.spec.ts
@@ -59,6 +59,20 @@ describe('SearchService', () => {
     expect(tokenSql).toContain('WHEN "name" ILIKE $3 THEN 2');
   });
 
+  it('full-text searches the token symbol via to_tsvector/websearch_to_tsquery', async () => {
+    prisma.$queryRawUnsafe.mockResolvedValue([]);
+    const service = new SearchService(prisma as never);
+
+    await service.search('usdc');
+
+    const tokenSql = prisma.$queryRawUnsafe.mock.calls[0][0] as string;
+    const tokenArgs = prisma.$queryRawUnsafe.mock.calls[0].slice(1);
+    expect(tokenSql).toContain(
+      `to_tsvector('simple', "symbol") @@ websearch_to_tsquery('simple', $4)`,
+    );
+    expect(tokenArgs).toEqual(['usdc', 'usdc%', '%usdc%', 'usdc']);
+  });
+
   it('returns empty arrays when no matches are found', async () => {
     prisma.$queryRawUnsafe.mockResolvedValue([]);
     const service = new SearchService(prisma as never);

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -60,11 +60,13 @@ export class SearchService {
           lower("address") = lower($1)
           OR "symbol" ILIKE $2
           OR "name" ILIKE $3
+          OR to_tsvector('simple', "symbol") @@ websearch_to_tsquery('simple', $4)
         ORDER BY
           CASE
             WHEN lower("symbol") = lower($1) THEN 0
             WHEN lower("address") = lower($1) THEN 0
             WHEN "symbol" ILIKE $2 THEN 1
+            WHEN to_tsvector('simple', "symbol") @@ websearch_to_tsquery('simple', $4) THEN 1
             WHEN "name" ILIKE $3 THEN 2
             ELSE 3
           END,
@@ -75,6 +77,7 @@ export class SearchService {
       query,
       `${query}%`,
       `%${query}%`,
+      query,
     );
   }
 

--- a/prisma/migrations/20260629000000_add_token_symbol_fts_index/migration.sql
+++ b/prisma/migrations/20260629000000_add_token_symbol_fts_index/migration.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS token_symbol_fts_idx
+  ON "token" USING gin (to_tsvector('simple', "symbol"));


### PR DESCRIPTION
…, token FTS

- pools: deterministic tie-break by id when tvl/volume/apr are equal
- candles: aggregate 1h candles from existing 5m buckets instead of raw swaps
- candles: backfill missing candles for every interval since the first swap, run once on worker startup before the cron schedule
- search: full-text search on token symbol via to_tsvector/websearch_to_tsquery, backed by a new GIN index

Closes  #389, 
closes  #390,
closes  #391, 
closes  #392

## Summary

<!-- What does this PR do? -->

## Related issue

- Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed
