### PR TITLE
feat: add OpenAPI tag for admin routes

### DIFF
--- a/apps/api/src/admin/analytics.controller.spec.ts
+++ b/apps/api/src/admin/analytics.controller.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { InternalKeyGuard } from './internal-key.guard';
+
+const mockService = {
+  getOverview: jest.fn().mockResolvedValue({ totalTvl: 0, totalSwapCount: 0 }),
+  getTvl: jest.fn().mockResolvedValue({ interval: '7d', series: [] }),
+  getVolume: jest.fn().mockResolvedValue({ interval: '7d', series: [] }),
+  getFees: jest.fn().mockResolvedValue({ byPool: [] }),
+};
+
+describe('AnalyticsController', () => {
+  let controller: AnalyticsController;
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [
+        { provide: AnalyticsService, useValue: mockService },
+        { provide: InternalKeyGuard, useValue: { canActivate: () => true } },
+      ],
+    }).compile();
+
+    controller = module.get<AnalyticsController>(AnalyticsController);
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('returns the analytics overview', async () => {
+    mockService.getOverview.mockResolvedValue({ totalTvl: 1000 });
+
+    const result = await controller.getOverview();
+
+    expect(mockService.getOverview).toHaveBeenCalled();
+    expect(result).toEqual({ totalTvl: 1000 });
+  });
+
+  it('returns TVL timeseries', async () => {
+    mockService.getTvl.mockResolvedValue({ interval: '7d', series: [] });
+
+    const result = await controller.getTvl({ interval: '7d' } as any);
+
+    expect(mockService.getTvl).toHaveBeenCalledWith('7d');
+    expect(result).toEqual({ interval: '7d', series: [] });
+  });
+
+  it('returns volume timeseries', async () => {
+    mockService.getVolume.mockResolvedValue({ interval: '1d', series: [] });
+
+    const result = await controller.getVolume({ interval: '1d' } as any);
+
+    expect(mockService.getVolume).toHaveBeenCalledWith('1d');
+    expect(result).toEqual({ interval: '1d', series: [] });
+  });
+
+  it('returns fee totals', async () => {
+    mockService.getFees.mockResolvedValue({ byPool: [{ poolId: 'p1', feesAmount0: '10', feesAmount1: '20' }] });
+
+    const result = await controller.getFees();
+
+    expect(mockService.getFees).toHaveBeenCalled();
+    expect(result).toEqual({ byPool: [{ poolId: 'p1', feesAmount0: '10', feesAmount1: '20' }] });
+  });
+});

--- a/apps/api/src/admin/analytics.controller.ts
+++ b/apps/api/src/admin/analytics.controller.ts
@@ -1,8 +1,11 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { AnalyticsService } from './analytics.service';
 import { InternalKeyGuard } from './internal-key.guard';
 import { TimeSeriesQueryDto } from './dto/analytics-query.dto';
+import { SWAGGER_TAGS } from '../swagger.constants';
 
+@ApiTags(SWAGGER_TAGS.ADMIN)
 @Controller('admin/analytics')
 @UseGuards(InternalKeyGuard)
 export class AnalyticsController {

--- a/apps/api/src/app.smoke.spec.ts
+++ b/apps/api/src/app.smoke.spec.ts
@@ -134,4 +134,13 @@ describe('AppModule — public routes smoke test', () => {
 
   it('POST /auth/nonce returns 200 (no body)', () =>
     request(app.getHttpServer()).post('/auth/nonce').expect(200));
+
+  it('GET /docs-json returns the OpenAPI spec', async () => {
+    const res = await request(app.getHttpServer()).get('/docs-json').expect(200);
+    const doc = res.body as { tags?: { name: string }[]; paths?: Record<string, unknown> };
+    const tagNames = (doc.tags ?? []).map((t) => t.name);
+    expect(tagNames).toContain('admin');
+    const pathKeys = Object.keys(doc.paths ?? {});
+    expect(pathKeys.some((p) => p.startsWith('/admin/analytics'))).toBe(true);
+  });
 });

--- a/apps/api/src/swagger.constants.ts
+++ b/apps/api/src/swagger.constants.ts
@@ -26,6 +26,9 @@ export const SWAGGER_TAGS = {
   /** Indexer status and queue-health endpoints. */
   INDEXER: 'indexer',
 
+  /** Internal analytics and monitoring endpoints. */
+  ADMIN: 'admin',
+
   /** Transaction relay endpoints. */
   TRANSACTIONS: 'transactions',
 } as const;


### PR DESCRIPTION
- Add ADMIN tag constant to SWAGGER_TAGS
- Decorate AnalyticsController with @ApiTags(ADMIN)
- Verify /docs-json exposes the admin tag and analytics paths

## Summary

<!-- What does this PR do? -->

## Related issue

- Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed
closes #413
