### PR TITLE
feat: add worker lag metrics endpoint

### DIFF
--- a/apps/api/src/metrics/metrics.controller.spec.ts
+++ b/apps/api/src/metrics/metrics.controller.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for MetricsController - worker lag and db metrics endpoints.
+ */
+
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { MetricsModule } from './metrics.module';
+import { CacheService } from '../cache/cache.service';
+import { IndexerMonitorService } from './indexer-monitor.service';
+import { DbMetricsService } from './db-metrics.service';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const noop = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('ioredis', () =>
+  jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    get: jest.fn().mockResolvedValue(null),
+    set: noop,
+    setex: noop,
+    del: noop,
+    publish: noop,
+    connect: noop,
+    quit: noop,
+  })),
+);
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('MetricsController (smoke)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [MetricsModule],
+    })
+      .overrideProvider(CacheService)
+      .useValue({ get: jest.fn().mockResolvedValue(null), set: noop })
+      .compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /metrics/worker-lag returns indexer metrics', async () => {
+    const result = await request(app.getHttpServer())
+      .get('/metrics/worker-lag')
+      .expect(200)
+      .then((res) => res.body);
+
+    expect(result).toHaveProperty('lastIndexedLedger');
+    expect(result).toHaveProperty('latestLedger');
+    expect(result).toHaveProperty('lagLedgers');
+    expect(result).toHaveProperty('lagSeconds');
+    expect(result).toHaveProperty('status');
+  });
+});

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -4,16 +4,31 @@ import {
   Headers,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { DbMetricsService } from './db-metrics.service';
+import { IndexerMonitorService } from './indexer-monitor.service';
+import { SWAGGER_TAGS } from '../swagger.constants';
 
+@ApiTags(SWAGGER_TAGS.INDEXER)
 @Controller('metrics')
 export class MetricsController {
-  constructor(private readonly dbMetrics: DbMetricsService) {}
+  constructor(
+    private readonly dbMetrics: DbMetricsService,
+    private readonly indexerMonitor: IndexerMonitorService,
+  ) {}
 
   @Get('db')
   async getDbMetrics(@Headers('x-internal-key') key: string) {
     const expected = process.env.INTERNAL_API_KEY;
     if (!expected || key !== expected) throw new UnauthorizedException();
     return this.dbMetrics.snapshot();
+  }
+
+  @Get('worker-lag')
+  @ApiOperation({
+    summary: 'Worker lag metrics — use to monitor indexer catchup speed',
+  })
+  async getWorkerLag() {
+    return this.indexerMonitor.getMetrics();
   }
 }

--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { CacheModule } from '../cache/cache.module';
 import { DbMetricsService } from './db-metrics.service';
 import { MetricsController } from './metrics.controller';
+import { IndexerMonitorService } from './indexer-monitor.service';
 
 @Module({
   imports: [CacheModule],
-  providers: [DbMetricsService],
+  providers: [DbMetricsService, IndexerMonitorService],
   controllers: [MetricsController],
-  exports: [DbMetricsService],
+  exports: [DbMetricsService, IndexerMonitorService],
 })
 export class MetricsModule {}


### PR DESCRIPTION
- Add GET /metrics/worker-lag endpoint to expose indexer lag metrics
- Endpoint returns lastIndexedLedger, latestLedger, lagLedgers, lagSeconds, and status
- No authentication required for this public metrics endpoint
- Add IndexerMonitorService to MetricsModule providers and exports
- Add smoke test for the new endpoint

## Summary

<!-- What does this PR do? -->

## Related issue

- Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [ ] Self-reviewed the diff
- [ ] Added or updated tests where relevant
- [ ] Docs updated if needed
closes #416
