### PR TITLE
Indexer: ledger/tokenId persistence, graceful shutdown, replay endpoint

### DIFF
--- a/apps/api/src/indexer/dto/replay.dto.ts
+++ b/apps/api/src/indexer/dto/replay.dto.ts
@@ -1,0 +1,13 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReplayDto {
+  @ApiProperty({
+    description: 'Re-enqueue every persisted event from this ledger onward',
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  fromLedger!: number;
+}

--- a/apps/api/src/indexer/indexer-replay.service.ts
+++ b/apps/api/src/indexer/indexer-replay.service.ts
@@ -1,0 +1,229 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Queue } from 'bullmq';
+import { PrismaClient } from '@prisma/client';
+import {
+  QUEUE_POOL_CREATED,
+  QUEUE_SWAP_PROCESSED,
+  QUEUE_POSITION_MINTED,
+  QUEUE_POSITION_BURNED,
+  QUEUE_FEES_COLLECTED,
+  PoolCreatedJobData,
+  SwapProcessedJobData,
+  PositionMintedJobData,
+  PositionBurnedJobData,
+  FeesCollectedJobData,
+} from './queues';
+
+export interface ReplaySummary {
+  fromLedger: number;
+  enqueued: {
+    poolCreated: number;
+    swapProcessed: number;
+    positionMinted: number;
+    positionBurned: number;
+    feesCollected: number;
+  };
+  total: number;
+}
+
+/**
+ * Re-enqueues persisted events from `fromLedger` onward onto their BullMQ
+ * queues so they're reprojected. Handlers upsert on eventId, so replayed
+ * events that already landed are safely re-applied rather than duplicated.
+ * Rows persisted before the `ledger` column existed have `ledger: null` and
+ * are not replayable — only events tagged with a ledger can be selected.
+ */
+@Injectable()
+export class IndexerReplayService {
+  private readonly logger = new Logger(IndexerReplayService.name);
+  private readonly prisma = new PrismaClient();
+  private static readonly ENQUEUE_OPTS = { removeOnComplete: true };
+
+  constructor(
+    @Inject(QUEUE_POOL_CREATED)
+    private readonly poolCreatedQueue: Queue<PoolCreatedJobData>,
+    @Inject(QUEUE_SWAP_PROCESSED)
+    private readonly swapProcessedQueue: Queue<SwapProcessedJobData>,
+    @Inject(QUEUE_POSITION_MINTED)
+    private readonly positionMintedQueue: Queue<PositionMintedJobData>,
+    @Inject(QUEUE_POSITION_BURNED)
+    private readonly positionBurnedQueue: Queue<PositionBurnedJobData>,
+    @Inject(QUEUE_FEES_COLLECTED)
+    private readonly feesCollectedQueue: Queue<FeesCollectedJobData>,
+  ) {}
+
+  async replayFromLedger(fromLedger: number): Promise<ReplaySummary> {
+    const [
+      poolCreated,
+      swapProcessed,
+      positionMinted,
+      positionBurned,
+      feesCollected,
+    ] = await Promise.all([
+      this.replayPoolCreated(fromLedger),
+      this.replaySwapProcessed(fromLedger),
+      this.replayPositionMinted(fromLedger),
+      this.replayPositionBurned(fromLedger),
+      this.replayFeesCollected(fromLedger),
+    ]);
+
+    const total =
+      poolCreated +
+      swapProcessed +
+      positionMinted +
+      positionBurned +
+      feesCollected;
+
+    this.logger.log(
+      `Replay from ledger ${fromLedger} enqueued ${total} event(s) ` +
+        `(pool.created=${poolCreated}, swap.processed=${swapProcessed}, ` +
+        `position.minted=${positionMinted}, position.burned=${positionBurned}, ` +
+        `fees.collected=${feesCollected})`,
+    );
+
+    return {
+      fromLedger,
+      enqueued: {
+        poolCreated,
+        swapProcessed,
+        positionMinted,
+        positionBurned,
+        feesCollected,
+      },
+      total,
+    };
+  }
+
+  private async replayPoolCreated(fromLedger: number): Promise<number> {
+    const rows = await this.prisma.poolCreated.findMany({
+      where: { ledger: { gte: fromLedger } },
+      orderBy: { ledger: 'asc' },
+    });
+    if (!rows.length) return 0;
+
+    await this.poolCreatedQueue.addBulk(
+      rows.map((row) => ({
+        name: row.eventId,
+        data: {
+          eventId: row.eventId,
+          poolId: row.poolId,
+          tokenA: row.tokenA,
+          tokenB: row.tokenB,
+          fee: row.fee,
+          sqrtPriceX96: row.sqrtPriceX96,
+          ledger: row.ledger ?? undefined,
+        } satisfies PoolCreatedJobData,
+        opts: IndexerReplayService.ENQUEUE_OPTS,
+      })),
+    );
+    return rows.length;
+  }
+
+  private async replaySwapProcessed(fromLedger: number): Promise<number> {
+    const rows = await this.prisma.swapProcessed.findMany({
+      where: { ledger: { gte: fromLedger } },
+      orderBy: { ledger: 'asc' },
+    });
+    if (!rows.length) return 0;
+
+    await this.swapProcessedQueue.addBulk(
+      rows.map((row) => ({
+        name: row.eventId,
+        data: {
+          eventId: row.eventId,
+          poolId: row.poolId,
+          sender: row.sender,
+          recipient: row.recipient,
+          amount0: row.amount0,
+          amount1: row.amount1,
+          sqrtPriceX96: row.sqrtPriceX96,
+          liquidity: row.liquidity,
+          tick: row.tick,
+          ledger: row.ledger ?? undefined,
+        } satisfies SwapProcessedJobData,
+        opts: IndexerReplayService.ENQUEUE_OPTS,
+      })),
+    );
+    return rows.length;
+  }
+
+  private async replayPositionMinted(fromLedger: number): Promise<number> {
+    const rows = await this.prisma.positionMinted.findMany({
+      where: { ledger: { gte: fromLedger } },
+      orderBy: { ledger: 'asc' },
+    });
+    if (!rows.length) return 0;
+
+    await this.positionMintedQueue.addBulk(
+      rows.map((row) => ({
+        name: row.eventId,
+        data: {
+          eventId: row.eventId,
+          poolId: row.poolId,
+          tokenId: row.tokenId ?? '',
+          owner: row.owner,
+          tickLower: row.tickLower,
+          tickUpper: row.tickUpper,
+          liquidity: row.liquidity,
+          amount0: row.amount0,
+          amount1: row.amount1,
+          ledger: row.ledger ?? undefined,
+        } satisfies PositionMintedJobData,
+        opts: IndexerReplayService.ENQUEUE_OPTS,
+      })),
+    );
+    return rows.length;
+  }
+
+  private async replayPositionBurned(fromLedger: number): Promise<number> {
+    const rows = await this.prisma.positionBurned.findMany({
+      where: { ledger: { gte: fromLedger } },
+      orderBy: { ledger: 'asc' },
+    });
+    if (!rows.length) return 0;
+
+    await this.positionBurnedQueue.addBulk(
+      rows.map((row) => ({
+        name: row.eventId,
+        data: {
+          eventId: row.eventId,
+          poolId: row.poolId,
+          tokenId: row.tokenId ?? '',
+          owner: row.owner,
+          tickLower: row.tickLower,
+          tickUpper: row.tickUpper,
+          liquidity: row.liquidity,
+          amount0: row.amount0,
+          amount1: row.amount1,
+          ledger: row.ledger ?? undefined,
+        } satisfies PositionBurnedJobData,
+        opts: IndexerReplayService.ENQUEUE_OPTS,
+      })),
+    );
+    return rows.length;
+  }
+
+  private async replayFeesCollected(fromLedger: number): Promise<number> {
+    const rows = await this.prisma.feesCollected.findMany({
+      where: { ledger: { gte: fromLedger } },
+      orderBy: { ledger: 'asc' },
+    });
+    if (!rows.length) return 0;
+
+    await this.feesCollectedQueue.addBulk(
+      rows.map((row) => ({
+        name: row.eventId,
+        data: {
+          eventId: row.eventId,
+          poolId: row.poolId,
+          recipient: row.recipient,
+          amount0: row.amount0,
+          amount1: row.amount1,
+          ledger: row.ledger ?? undefined,
+        } satisfies FeesCollectedJobData,
+        opts: IndexerReplayService.ENQUEUE_OPTS,
+      })),
+    );
+    return rows.length;
+  }
+}

--- a/apps/api/src/indexer/indexer.controller.ts
+++ b/apps/api/src/indexer/indexer.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { IndexerWorker } from './indexer.worker';
+import { IndexerReplayService, ReplaySummary } from './indexer-replay.service';
+import { ReplayDto } from './dto/replay.dto';
+import { InternalKeyGuard } from '../admin/internal-key.guard';
 import { SWAGGER_TAGS } from '../swagger.constants';
 
 export interface IndexerStatusResponse {
@@ -8,11 +11,12 @@ export interface IndexerStatusResponse {
   isLoading: boolean;
   /**
    * Human-readable status:
-   * - `initializing` — workers are starting up
-   * - `idle`         — workers are running with empty queues
-   * - `processing`   — at least one queue has pending work
+   * - `initializing`  — workers are starting up
+   * - `idle`          — workers are running with empty queues
+   * - `processing`    — at least one queue has pending work
+   * - `shutting_down` — a SIGTERM/SIGINT was received; draining in-flight jobs
    */
-  status: 'initializing' | 'idle' | 'processing';
+  status: 'initializing' | 'idle' | 'processing' | 'shutting_down';
   /**
    * Copy shown to clients when the indexer has no data yet.
    * Explains the current state and suggests the next step.
@@ -23,7 +27,10 @@ export interface IndexerStatusResponse {
 @ApiTags(SWAGGER_TAGS.INDEXER)
 @Controller('indexer')
 export class IndexerController {
-  constructor(private readonly worker: IndexerWorker) {}
+  constructor(
+    private readonly worker: IndexerWorker,
+    private readonly replayService: IndexerReplayService,
+  ) {}
 
   /**
    * Returns the current status of the indexer worker.
@@ -36,6 +43,15 @@ export class IndexerController {
     summary: 'Indexer status — use to show empty-state copy while syncing',
   })
   getStatus(): IndexerStatusResponse {
+    if (this.worker.isShuttingDown) {
+      return {
+        isLoading: false,
+        status: 'shutting_down',
+        message:
+          'The indexer is shutting down and draining in-flight events. New events will resume processing shortly.',
+      };
+    }
+
     if (this.worker.isLoading) {
       return {
         isLoading: true,
@@ -51,5 +67,20 @@ export class IndexerController {
       message:
         'The indexer is running. Make a swap or add liquidity to start seeing your activity here.',
     };
+  }
+
+  /**
+   * Re-enqueues every persisted event with `ledger >= fromLedger` onto its
+   * BullMQ queue for reprocessing. Internal/operator use only — guarded by
+   * `x-internal-key` since replaying can trigger duplicate webhook deliveries
+   * for events that already landed (writes stay idempotent on eventId).
+   */
+  @Post('replay')
+  @UseGuards(InternalKeyGuard)
+  @ApiOperation({
+    summary: 'Replay persisted events from a given ledger onward (internal)',
+  })
+  replay(@Body() body: ReplayDto): Promise<ReplaySummary> {
+    return this.replayService.replayFromLedger(body.fromLedger);
   }
 }

--- a/apps/api/src/indexer/indexer.module.ts
+++ b/apps/api/src/indexer/indexer.module.ts
@@ -1,18 +1,29 @@
 import { Module } from '@nestjs/common';
 import { IndexerWorker } from './indexer.worker';
 import { IndexerController } from './indexer.controller';
-import { createQueue, QUEUE_NAMES } from './queues';
+import {
+  createQueue,
+  QUEUE_NAMES,
+  QUEUE_POOL_CREATED,
+  QUEUE_SWAP_PROCESSED,
+  QUEUE_POSITION_MINTED,
+  QUEUE_POSITION_BURNED,
+  QUEUE_FEES_COLLECTED,
+} from './queues';
 import { CacheModule } from '../cache/cache.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { TokensModule } from '../tokens/tokens.module';
 import { IndexerCursorService } from './indexer-cursor.service';
 import { IndexerDeadLetterService } from './indexer-dead-letter.service';
+import { IndexerReplayService } from './indexer-replay.service';
 
-export const QUEUE_POOL_CREATED = 'QUEUE_POOL_CREATED';
-export const QUEUE_SWAP_PROCESSED = 'QUEUE_SWAP_PROCESSED';
-export const QUEUE_POSITION_MINTED = 'QUEUE_POSITION_MINTED';
-export const QUEUE_POSITION_BURNED = 'QUEUE_POSITION_BURNED';
-export const QUEUE_FEES_COLLECTED = 'QUEUE_FEES_COLLECTED';
+export {
+  QUEUE_POOL_CREATED,
+  QUEUE_SWAP_PROCESSED,
+  QUEUE_POSITION_MINTED,
+  QUEUE_POSITION_BURNED,
+  QUEUE_FEES_COLLECTED,
+};
 
 @Module({
   imports: [CacheModule, WebhooksModule, TokensModule],
@@ -21,6 +32,7 @@ export const QUEUE_FEES_COLLECTED = 'QUEUE_FEES_COLLECTED';
     IndexerWorker,
     IndexerCursorService,
     IndexerDeadLetterService,
+    IndexerReplayService,
     {
       provide: QUEUE_POOL_CREATED,
       useFactory: () => createQueue(QUEUE_NAMES.POOL_CREATED),

--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -13,11 +13,13 @@ import { IndexerDeadLetterService } from './indexer-dead-letter.service';
 import {
   QUEUE_NAMES,
   makeQueueOptions,
+  getWorkerConcurrency,
   PoolCreatedJobData,
   SwapProcessedJobData,
   PositionMintedJobData,
   PositionBurnedJobData,
   FeesCollectedJobData,
+  QueueName,
 } from './queues';
 import { PoolsRepository } from '../pools/pools.repository';
 
@@ -37,6 +39,11 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
   private queueDepthTimer: NodeJS.Timeout | null = null;
   private _isLoading = false;
   private _isReady = false;
+  private _isShuttingDown = false;
+  /** Bounds how long a SIGTERM/SIGINT shutdown waits for in-flight jobs before giving up. */
+  private static readonly SHUTDOWN_TIMEOUT_MS = Number(
+    process.env.INDEXER_SHUTDOWN_TIMEOUT_MS ?? 25_000,
+  );
 
   constructor(
     private readonly webhooks: WebhooksService,
@@ -47,6 +54,11 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   get isLoading(): boolean {
     return this._isLoading;
+  }
+
+  /** True from the moment a shutdown signal is received until cleanup finishes. */
+  get isShuttingDown(): boolean {
+    return this._isShuttingDown;
   }
 
   async onModuleInit() {
@@ -94,16 +106,52 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
     );
   }
 
+  /**
+   * Invoked by Nest's shutdown hooks on SIGTERM/SIGINT (see main.ts's
+   * `enableShutdownHooks()`). Stops routing new jobs immediately, then lets
+   * BullMQ drain in-flight jobs — bounded by SHUTDOWN_TIMEOUT_MS so a stuck
+   * job cannot hang the process past its deploy platform's kill timeout.
+   */
   async onModuleDestroy() {
+    this._isShuttingDown = true;
     this._isReady = false;
+    this.logger.log(
+      `Received shutdown signal — draining in-flight jobs (timeout ${IndexerWorker.SHUTDOWN_TIMEOUT_MS}ms)`,
+    );
     if (this.queueDepthTimer) clearInterval(this.queueDepthTimer);
-    await Promise.all([
+
+    const closeAll = Promise.all([
       ...this.workers.map((w) => w.close()),
       ...this.queueEvents.map((qe) => qe.close()),
     ]);
+    await this.withTimeout(
+      closeAll,
+      IndexerWorker.SHUTDOWN_TIMEOUT_MS,
+      'Timed out waiting for indexer workers to drain in-flight jobs — forcing shutdown',
+    );
+
     await this.prisma.$disconnect();
     this._isLoading = false;
+    this._isShuttingDown = false;
     this.logger.log('Indexer workers shut down gracefully');
+  }
+
+  /** Races `promise` against a timeout, logging (but not throwing) if the timeout wins. */
+  private async withTimeout(
+    promise: Promise<unknown>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<void> {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(() => {
+        this.logger.warn(timeoutMessage);
+        resolve();
+      }, timeoutMs);
+    });
+
+    await Promise.race([promise.then(() => undefined), timeout]);
+    clearTimeout(timer!);
   }
 
   private makeWorker<T>(
@@ -127,6 +175,9 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
       lockDuration: 60_000,
       stalledInterval: 30_000,
       maxStalledCount: 2,
+      // Each event type is an independent, idempotent projection, so jobs of
+      // the same type can safely run in parallel within this worker process.
+      concurrency: getWorkerConcurrency(queueName as QueueName),
     });
 
     worker.on('completed', (job) => {
@@ -226,6 +277,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         tokenB: d.tokenB,
         fee: d.fee,
         sqrtPriceX96: d.sqrtPriceX96,
+        ledger: d.ledger ?? null,
       },
     });
 
@@ -266,6 +318,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         sqrtPriceX96: d.sqrtPriceX96,
         liquidity: d.liquidity,
         tick: d.tick,
+        ledger: d.ledger ?? null,
       },
     });
 
@@ -302,12 +355,14 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
       create: {
         eventId: d.eventId,
         poolId: d.poolId,
+        tokenId: d.tokenId || null,
         owner: d.owner,
         tickLower: d.tickLower,
         tickUpper: d.tickUpper,
         liquidity: d.liquidity,
         amount0: d.amount0,
         amount1: d.amount1,
+        ledger: d.ledger ?? null,
       },
     });
     // Project into relational Position table when the event includes a tokenId.
@@ -338,12 +393,14 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
       create: {
         eventId: d.eventId,
         poolId: d.poolId,
+        tokenId: d.tokenId || null,
         owner: d.owner,
         tickLower: d.tickLower,
         tickUpper: d.tickUpper,
         liquidity: d.liquidity,
         amount0: d.amount0,
         amount1: d.amount1,
+        ledger: d.ledger ?? null,
       },
     });
     // Project into relational Position table when the event includes a tokenId.
@@ -382,6 +439,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
         recipient: d.recipient,
         amount0: d.amount0,
         amount1: d.amount1,
+        ledger: d.ledger ?? null,
       },
     });
     await this.advanceLedger(job.id, d.ledger);

--- a/apps/api/src/indexer/queues.ts
+++ b/apps/api/src/indexer/queues.ts
@@ -94,3 +94,21 @@ export function makeQueueOptions(): QueueOptions {
 export function createQueue(name: QueueName): Queue {
   return new Queue(name, makeQueueOptions());
 }
+
+const DEFAULT_WORKER_CONCURRENCY = 5;
+
+/**
+ * Per-queue BullMQ worker concurrency. Each event type is an independent,
+ * idempotent projection, so jobs of the same type can safely run in parallel
+ * within a worker process. Overridable per queue via
+ * `INDEXER_CONCURRENCY_<QUEUE_NAME>` (queue name upper-cased, dots to
+ * underscores), falling back to `INDEXER_CONCURRENCY` and finally the default.
+ */
+export function getWorkerConcurrency(queueName: QueueName): number {
+  const envKey = `INDEXER_CONCURRENCY_${queueName.toUpperCase().replace(/\./g, '_')}`;
+  const raw = process.env[envKey] ?? process.env.INDEXER_CONCURRENCY;
+  const parsed = raw !== undefined ? Number(raw) : NaN;
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_WORKER_CONCURRENCY;
+}

--- a/apps/api/src/indexer/queues.ts
+++ b/apps/api/src/indexer/queues.ts
@@ -10,6 +10,15 @@ export const QUEUE_NAMES = {
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
 
+// DI tokens for each queue's BullMQ Queue provider. Defined here (rather
+// than in indexer.module.ts) so indexer-replay.service.ts can import them
+// without a module -> service -> module circular import.
+export const QUEUE_POOL_CREATED = 'QUEUE_POOL_CREATED';
+export const QUEUE_SWAP_PROCESSED = 'QUEUE_SWAP_PROCESSED';
+export const QUEUE_POSITION_MINTED = 'QUEUE_POSITION_MINTED';
+export const QUEUE_POSITION_BURNED = 'QUEUE_POSITION_BURNED';
+export const QUEUE_FEES_COLLECTED = 'QUEUE_FEES_COLLECTED';
+
 /**
  * Metadata shared by all events emitted by the ledger indexer. `ledger` is
  * optional while upstream producers are rolled out; events without it are

--- a/prisma/migrations/20260724000000_indexer_ledger_and_position_tokenid/migration.sql
+++ b/prisma/migrations/20260724000000_indexer_ledger_and_position_tokenid/migration.sql
@@ -1,0 +1,20 @@
+-- Persist the source ledger on every raw event row so a replay can select
+-- "everything from ledger N onward" directly from Postgres instead of
+-- requiring an external re-fetch from Horizon.
+ALTER TABLE "pool_created" ADD COLUMN "ledger" INTEGER;
+ALTER TABLE "swap_processed" ADD COLUMN "ledger" INTEGER;
+ALTER TABLE "position_minted" ADD COLUMN "ledger" INTEGER;
+ALTER TABLE "position_burned" ADD COLUMN "ledger" INTEGER;
+ALTER TABLE "fees_collected" ADD COLUMN "ledger" INTEGER;
+
+CREATE INDEX IF NOT EXISTS "pool_created_ledger_idx" ON "pool_created"("ledger");
+CREATE INDEX IF NOT EXISTS "swap_processed_ledger_idx" ON "swap_processed"("ledger");
+CREATE INDEX IF NOT EXISTS "position_minted_ledger_idx" ON "position_minted"("ledger");
+CREATE INDEX IF NOT EXISTS "position_burned_ledger_idx" ON "position_burned"("ledger");
+CREATE INDEX IF NOT EXISTS "fees_collected_ledger_idx" ON "fees_collected"("ledger");
+
+-- Position events didn't retain their NFT/position identifier, so a mint or
+-- burn couldn't be distinguished from another in the same pool with the same
+-- ticks when reprojecting the relational Position row on replay.
+ALTER TABLE "position_minted" ADD COLUMN "tokenId" TEXT;
+ALTER TABLE "position_burned" ADD COLUMN "tokenId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,9 +177,11 @@ model PoolCreated {
   tokenB       String
   fee          String
   sqrtPriceX96 String
+  ledger       Int?
   createdAt    DateTime @default(now())
 
   @@index([poolId])
+  @@index([ledger])
   @@map("pool_created")
 }
 
@@ -193,39 +195,51 @@ model SwapProcessed {
   sqrtPriceX96 String
   liquidity    String
   tick         Int
+  ledger       Int?
   createdAt    DateTime @default(now())
 
   @@index([poolId, createdAt])
+  @@index([ledger])
   @@map("swap_processed")
 }
 
 model PositionMinted {
   eventId    String   @id
   poolId     String
+  /// Pool-local NFT/position identifier; nullable for events emitted before
+  /// this field was tracked.
+  tokenId    String?
   owner      String
   tickLower  Int
   tickUpper  Int
   liquidity  String
   amount0    String
   amount1    String
+  ledger     Int?
   createdAt  DateTime @default(now())
 
   @@index([poolId])
+  @@index([ledger])
   @@map("position_minted")
 }
 
 model PositionBurned {
   eventId    String   @id
   poolId     String
+  /// Pool-local NFT/position identifier; nullable for events emitted before
+  /// this field was tracked.
+  tokenId    String?
   owner      String
   tickLower  Int
   tickUpper  Int
   liquidity  String
   amount0    String
   amount1    String
+  ledger     Int?
   createdAt  DateTime @default(now())
 
   @@index([poolId])
+  @@index([ledger])
   @@map("position_burned")
 }
 
@@ -235,9 +249,11 @@ model FeesCollected {
   recipient String
   amount0   String
   amount1   String
+  ledger    Int?
   createdAt DateTime @default(now())
 
   @@index([poolId])
+  @@index([ledger])
   @@map("fees_collected")
 }
 


### PR DESCRIPTION
## Summary
- Persist the source `ledger` on every raw indexer event row, and `tokenId` on position mint/burn rows, so a targeted replay can select "everything from ledger N onward" directly from Postgres and correctly reproject positions.
- `IndexerWorker.onModuleDestroy` now drains in-flight BullMQ jobs with a bounded timeout instead of closing workers unconditionally, and exposes `isShuttingDown` so `GET /indexer/status` can report a `shutting_down` state.
- Each queue's worker concurrency is now configurable (`INDEXER_CONCURRENCY[_<QUEUE_NAME>]`) instead of BullMQ's default of 1, since each event type projects independently and idempotently.
- New internal `POST /indexer/replay` endpoint (guarded by `InternalKeyGuard`) re-enqueues persisted events from a given ledger onward for reprocessing; safe because handlers upsert on `eventId`.

## Test plan
- [x] `npx tsc --noEmit` — no new errors vs. main (diffed against baseline; same pre-existing unrelated errors in `horizon.service.ts`, `indexer-cursor.service.ts`, `metrics.controller.ts`, `pools.service.ts`, `tokens.controller.ts`)
- [x] `npx eslint` / `npx prettier --check` on all changed files — clean
- [x] `npx jest src/indexer` — same 26 pre-existing failures as on main (19 in `indexer.worker.integration.spec.ts` due to a pre-existing DI gap in that spec's own test module setup, 7 in `indexer.spec.ts`'s `IndexerModule` describe block due to a pre-existing `ConfigService`/`TokensModule` DI issue) — no new failures, 75 passing
- [x] `npx prisma generate` succeeds against the updated schema
- [ ] `prisma migrate deploy` against a real Postgres instance (not run — no live DB in this environment)

Closes #476
Closes #477
Closes #478
Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)