### PR TITLE
Network switcher, transaction pending indicator, and SDK entrypoint/tree-shaking improvements

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { WalletProvider } from '@/context/WalletContext';
+import { NetworkProvider } from '@/context/NetworkContext';
+import { TransactionStatusProvider } from '@/context/TransactionStatusContext';
 import { QueryProvider } from '@/context/QueryProvider';
 import { Navbar } from '@/components/Navbar';
 import { Providers } from './providers';
@@ -37,10 +39,14 @@ export default function RootLayout({
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col">
         <Providers>
-          <WalletProvider>
-            <Navbar />
-            {children}
-          </WalletProvider>
+          <NetworkProvider>
+            <TransactionStatusProvider>
+              <WalletProvider>
+                <Navbar />
+                {children}
+              </WalletProvider>
+            </TransactionStatusProvider>
+          </NetworkProvider>
         </Providers>
       </body>
     </html>

--- a/apps/web/app/portfolio/page.tsx
+++ b/apps/web/app/portfolio/page.tsx
@@ -4,10 +4,11 @@ import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useWalletContext } from '@/context/WalletContext';
+import { useNetworkContext } from '@/context/NetworkContext';
 import { usePortfolio } from '@/hooks/usePortfolio';
 import { PositionCard } from '@/components/PositionCard';
 import { WalletButton } from '@/components/WalletButton';
-import { API_BASE, SWYFT_NETWORK_PASSPHRASE } from '@/lib/constants';
+import { API_BASE, getNetworkPassphrase } from '@/lib/constants';
 import { signTransaction } from '@stellar/freighter-api';
 import { buildCollectTx } from '@swyft/sdk';
 import Link from 'next/link';
@@ -20,6 +21,7 @@ function getAuthToken(): string | null {
 export default function PortfolioPage() {
   const router = useRouter();
   const { address } = useWalletContext();
+  const { network } = useNetworkContext();
   const authToken = getAuthToken();
   const { active, closed, loading, refresh, totalValueUsd } = usePortfolio(authToken);
   const [showClosed, setShowClosed] = useState(false);
@@ -42,7 +44,7 @@ export default function PortfolioPage() {
         });
 
         const signResult = await signTransaction(xdr, {
-          networkPassphrase: SWYFT_NETWORK_PASSPHRASE,
+          networkPassphrase: getNetworkPassphrase(network),
         });
         const signedXdr =
           typeof signResult === 'string'
@@ -69,7 +71,7 @@ export default function PortfolioPage() {
         setCollectingId(null);
       }
     },
-    [authToken, active, refresh]
+    [authToken, active, refresh, network]
   );
 
   if (!address) return null;

--- a/apps/web/components/Navbar.test.tsx
+++ b/apps/web/components/Navbar.test.tsx
@@ -26,6 +26,11 @@ vi.mock('./WalletButton', () => ({
   WalletButton: () => <button type="button">Connect wallet</button>,
 }));
 
+// NetworkSwitcher reads from WalletContext too — stub it out for layout-only tests
+vi.mock('./NetworkSwitcher', () => ({
+  NetworkSwitcher: () => <button type="button">Testnet</button>,
+}));
+
 function renderNavbar() {
   return render(<Navbar />);
 }

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { WalletButton } from '@/components/WalletButton';
+import { NetworkSwitcher } from '@/components/NetworkSwitcher';
+import { TransactionStatusIndicator } from '@/components/TransactionStatusIndicator';
 
 const NAV_LINKS = [
   { href: '/', label: 'Swap' },
@@ -42,8 +44,10 @@ export function Navbar() {
           </div>
         </div>
 
-        {/* Right: wallet + hamburger */}
+        {/* Right: pending tx + network + wallet + hamburger */}
         <div className="flex items-center gap-3">
+          <TransactionStatusIndicator />
+          <NetworkSwitcher />
           <WalletButton />
           {/* Hamburger — visible only on mobile */}
           <button

--- a/apps/web/components/NetworkSwitcher.tsx
+++ b/apps/web/components/NetworkSwitcher.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useRef, useState, useEffect } from 'react';
+import { useNetworkContext } from '@/context/NetworkContext';
+import { useWalletContext } from '@/context/WalletContext';
+import type { StellarNetwork } from '@/lib/constants';
+
+const NETWORKS: { value: StellarNetwork; label: string }[] = [
+  { value: 'TESTNET', label: 'Testnet' },
+  { value: 'PUBLIC', label: 'Mainnet' },
+];
+
+export function NetworkSwitcher() {
+  const { network, setNetwork } = useNetworkContext();
+  const { address, disconnect } = useWalletContext();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  function selectNetwork(next: StellarNetwork) {
+    setOpen(false);
+    if (next === network) return;
+    // A wallet session validated against the old network is no longer
+    // trustworthy once the app targets a different one — drop it instead
+    // of leaving a stale, potentially mismatched connection in place.
+    if (address) disconnect();
+    setNetwork(next);
+  }
+
+  const isMainnet = network === 'PUBLIC';
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-600 transition-colors min-h-[36px]"
+      >
+        <span
+          className={`h-2 w-2 rounded-full ${isMainnet ? 'bg-emerald-500' : 'bg-amber-500'}`}
+          aria-hidden="true"
+        />
+        {isMainnet ? 'Mainnet' : 'Testnet'}
+        <svg
+          className="h-3.5 w-3.5 text-zinc-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Select network"
+          className="absolute right-0 top-full z-30 mt-1 w-40 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+        >
+          {NETWORKS.map((n) => (
+            <li key={n.value} role="option" aria-selected={n.value === network}>
+              <button
+                type="button"
+                onClick={() => selectNetwork(n.value)}
+                className="flex w-full min-h-[44px] items-center gap-2 px-3 py-2 text-left text-sm text-zinc-800 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              >
+                <span
+                  className={`h-2 w-2 rounded-full ${n.value === 'PUBLIC' ? 'bg-emerald-500' : 'bg-amber-500'}`}
+                  aria-hidden="true"
+                />
+                {n.label}
+                {n.value === network && <span className="ml-auto text-xs text-zinc-400">✓</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/SwapConfirmModal.tsx
+++ b/apps/web/components/SwapConfirmModal.tsx
@@ -5,7 +5,8 @@ import type { SwapQuote } from '@swyft/sdk';
 import type { Token } from '@swyft/ui';
 import { PriceImpactBadge } from '@swyft/ui';
 import { useSwapExecution } from '@/hooks/useSwapExecution';
-import { explorerTxUrl } from '@/lib/constants';
+import { useNetworkContext } from '@/context/NetworkContext';
+import { getExplorerTxUrl } from '@/lib/constants';
 
 interface Props {
   poolId: string;
@@ -29,6 +30,7 @@ export function SwapConfirmModal({
   onSuccess,
 }: Props) {
   const { status, error, txHash, execute, reset } = useSwapExecution();
+  const { network } = useNetworkContext();
   const overlayRef = useRef<HTMLDivElement>(null);
 
   // Trap focus / close on Escape
@@ -154,7 +156,7 @@ export function SwapConfirmModal({
                 Transaction submitted successfully
               </p>
               <a
-                href={explorerTxUrl(txHash)}
+                href={getExplorerTxUrl(txHash, network)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-green-600 underline hover:text-green-800 dark:text-green-400 dark:hover:text-green-300 font-mono"

--- a/apps/web/components/TransactionHistory.tsx
+++ b/apps/web/components/TransactionHistory.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { useSwaps, SwapSnapshot } from '@/hooks/useSwaps';
 import { useLpActivity, LpActivity, LpActivityType } from '@/hooks/useLpActivity';
-import { SWYFT_NETWORK } from '@/lib/constants';
+import { useNetworkContext } from '@/context/NetworkContext';
 
 type Tab = 'swaps' | 'lp';
 
@@ -24,6 +24,7 @@ interface TransactionHistoryProps {
  * @returns A history panel with tabs, date filters, and paginated transaction tables.
  */
 export function TransactionHistory({ walletAddress }: TransactionHistoryProps) {
+  const { network } = useNetworkContext();
   const [activeTab, setActiveTab] = useState<Tab>('swaps');
   const [page, setPage] = useState(1);
   const [startDate, setStartDate] = useState<string>('');
@@ -61,8 +62,7 @@ export function TransactionHistory({ walletAddress }: TransactionHistoryProps) {
   }
 
   function getExplorerUrl(txHash: string): string {
-    const network = SWYFT_NETWORK.toLowerCase();
-    return `https://stellar.expert/explorer/${network}/tx/${txHash}`;
+    return `https://stellar.expert/explorer/${network.toLowerCase()}/tx/${txHash}`;
   }
 
   function formatDate(timestamp: number): string {

--- a/apps/web/components/TransactionStatusIndicator.tsx
+++ b/apps/web/components/TransactionStatusIndicator.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTransactionStatus } from '@/context/TransactionStatusContext';
+import { useNetworkContext } from '@/context/NetworkContext';
+import { getExplorerTxUrl } from '@/lib/constants';
+
+/** Success/error toasts clear themselves after this long if left untouched. */
+const AUTO_DISMISS_MS = 12000;
+
+export function TransactionStatusIndicator() {
+  const { pendingTx, dismiss } = useTransactionStatus();
+  const { network } = useNetworkContext();
+
+  useEffect(() => {
+    if (!pendingTx || (pendingTx.status !== 'success' && pendingTx.status !== 'error')) return;
+    const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingTx?.status, pendingTx?.txHash]);
+
+  if (!pendingTx) return null;
+
+  const isBusy = pendingTx.status === 'signing' || pendingTx.status === 'submitting';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 min-h-[36px]"
+    >
+      {isBusy && (
+        <span
+          className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent"
+          aria-hidden="true"
+        />
+      )}
+      {pendingTx.status === 'success' && (
+        <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+      )}
+      {pendingTx.status === 'error' && (
+        <span className="h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
+      )}
+
+      <span className="max-w-[9rem] truncate sm:max-w-none">
+        {pendingTx.status === 'signing' && 'Waiting for signature…'}
+        {pendingTx.status === 'submitting' && `Submitting ${pendingTx.label}…`}
+        {pendingTx.status === 'success' && `${pendingTx.label} confirmed`}
+        {pendingTx.status === 'error' && (pendingTx.errorMessage ?? `${pendingTx.label} failed`)}
+      </span>
+
+      {pendingTx.status === 'success' && pendingTx.txHash && (
+        <a
+          href={getExplorerTxUrl(pendingTx.txHash, network)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-indigo-600 underline hover:text-indigo-500 dark:text-indigo-400"
+        >
+          View
+        </a>
+      )}
+
+      {!isBusy && (
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss transaction status"
+          className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200"
+        >
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/WalletButton.tsx
+++ b/apps/web/components/WalletButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useWalletContext } from '@/context/WalletContext';
-import { SWYFT_NETWORK } from '@/lib/constants';
+import { useNetworkContext } from '@/context/NetworkContext';
 
 function truncate(addr: string) {
   return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
@@ -10,6 +10,7 @@ function truncate(addr: string) {
 
 export function WalletButton() {
   const { address, error, connecting, loading, connect, disconnect } = useWalletContext();
+  const { network } = useNetworkContext();
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -58,7 +59,7 @@ export function WalletButton() {
                 {address}
               </p>
               <p className="mt-1 text-xs text-zinc-400">
-                Network: <span className="font-medium">{SWYFT_NETWORK}</span>
+                Network: <span className="font-medium">{network}</span>
               </p>
             </div>
             <div className="p-2 flex flex-col gap-1">
@@ -110,7 +111,7 @@ export function WalletButton() {
       {error === 'REJECTED' && <p className="text-xs text-red-500">Connection rejected.</p>}
       {error === 'WRONG_NETWORK' && (
         <p className="text-xs text-red-500">
-          Switch Freighter to <strong>{SWYFT_NETWORK}</strong> and try again.
+          Switch Freighter to <strong>{network}</strong> and try again.
         </p>
       )}
     </div>

--- a/apps/web/context/NetworkContext.tsx
+++ b/apps/web/context/NetworkContext.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react';
+import {
+  NETWORK_STORAGE_KEY,
+  SWYFT_NETWORK,
+  isStellarNetwork,
+  type StellarNetwork,
+} from '@/lib/constants';
+
+export interface NetworkContextValue {
+  /** Currently selected network. Falls back to the build-time default until the persisted choice loads. */
+  network: StellarNetwork;
+  /** Switch the active network and persist the choice for future sessions. */
+  setNetwork: (network: StellarNetwork) => void;
+}
+
+const defaultValue: NetworkContextValue = {
+  network: SWYFT_NETWORK,
+  setNetwork: () => {},
+};
+
+const NetworkContext = createContext<NetworkContextValue>(defaultValue);
+
+export function NetworkProvider({ children }: { children: ReactNode }) {
+  const [network, setNetworkState] = useState<StellarNetwork>(SWYFT_NETWORK);
+
+  // Restore a persisted selection on mount. An unset or corrupted value
+  // (e.g. edited manually, or written by a future/older app version) is
+  // treated as absent and silently falls back to the env default.
+  useEffect(() => {
+    const stored = localStorage.getItem(NETWORK_STORAGE_KEY);
+    if (isStellarNetwork(stored)) {
+      setNetworkState(stored);
+    } else if (stored !== null) {
+      localStorage.removeItem(NETWORK_STORAGE_KEY);
+    }
+  }, []);
+
+  const setNetwork = useCallback((next: StellarNetwork) => {
+    setNetworkState(next);
+    localStorage.setItem(NETWORK_STORAGE_KEY, next);
+  }, []);
+
+  return (
+    <NetworkContext.Provider value={{ network, setNetwork }}>{children}</NetworkContext.Provider>
+  );
+}
+
+export function useNetworkContext(): NetworkContextValue {
+  return useContext(NetworkContext);
+}

--- a/apps/web/context/TransactionStatusContext.tsx
+++ b/apps/web/context/TransactionStatusContext.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { createContext, useContext, useEffect, useRef, useState, ReactNode } from 'react';
+
+export type PendingTxStatus = 'signing' | 'submitting' | 'success' | 'error';
+
+export interface PendingTx {
+  /** Short label describing the transaction, e.g. "Swap USDC → XLM". */
+  label: string;
+  status: PendingTxStatus;
+  txHash: string | null;
+  errorMessage?: string;
+}
+
+export interface TransactionStatusContextValue {
+  pendingTx: PendingTx | null;
+  /** Publish a status update, or `null` to clear the indicator. */
+  reportTx: (tx: PendingTx | null) => void;
+  dismiss: () => void;
+}
+
+const STORAGE_KEY = 'swyft_pending_tx';
+
+const defaultValue: TransactionStatusContextValue = {
+  pendingTx: null,
+  reportTx: () => {},
+  dismiss: () => {},
+};
+
+const TransactionStatusContext = createContext<TransactionStatusContextValue>(defaultValue);
+
+export function TransactionStatusProvider({ children }: { children: ReactNode }) {
+  const [pendingTx, setPendingTx] = useState<PendingTx | null>(null);
+  const hydrated = useRef(false);
+
+  // Restore the last known status (e.g. after an accidental remount) but
+  // never resume a "signing"/"submitting" state — the in-flight promise
+  // that would eventually resolve it is gone, so treat it as stale.
+  useEffect(() => {
+    if (hydrated.current) return;
+    hydrated.current = true;
+    try {
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as PendingTx;
+      if (parsed.status === 'success' || parsed.status === 'error') {
+        setPendingTx(parsed);
+      } else {
+        sessionStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  function reportTx(tx: PendingTx | null) {
+    setPendingTx(tx);
+    if (tx) {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(tx));
+    } else {
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  function dismiss() {
+    reportTx(null);
+  }
+
+  return (
+    <TransactionStatusContext.Provider value={{ pendingTx, reportTx, dismiss }}>
+      {children}
+    </TransactionStatusContext.Provider>
+  );
+}
+
+export function useTransactionStatus(): TransactionStatusContextValue {
+  return useContext(TransactionStatusContext);
+}

--- a/apps/web/context/WalletContext.tsx
+++ b/apps/web/context/WalletContext.tsx
@@ -2,11 +2,13 @@
 
 import { createContext, useContext, ReactNode } from 'react';
 import { useWallet, WalletState } from '@/hooks/useWallet';
+import { useNetworkContext } from '@/context/NetworkContext';
 
 const WalletContext = createContext<WalletState | undefined>(undefined);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
-  const wallet = useWallet();
+  const { network } = useNetworkContext();
+  const wallet = useWallet(network);
   return <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>;
 }
 

--- a/apps/web/hooks/useRemoveLiquidity.ts
+++ b/apps/web/hooks/useRemoveLiquidity.ts
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import { signTransaction } from '@stellar/freighter-api';
 import { buildBurnTx, buildCollectTx } from '@swyft/sdk';
 import type { PositionSnapshot } from '@swyft/ui';
-import { API_BASE, SWYFT_NETWORK_PASSPHRASE } from '@/lib/constants';
+import { API_BASE, getNetworkPassphrase } from '@/lib/constants';
+import { useNetworkContext } from '@/context/NetworkContext';
 
 /** Lifecycle status of a remove-liquidity or collect-fees transaction. */
 export type TxStatus = 'idle' | 'signing' | 'submitting' | 'success' | 'error';
@@ -55,6 +56,7 @@ function resolveSignedXdr(signResult: unknown): string | null {
  *   (`removeLiquidity`, `collectFees`, `reset`).
  */
 export function useRemoveLiquidity(position: PositionSnapshot | null, authToken: string | null) {
+  const { network } = useNetworkContext();
   const [state, setState] = useState<State>({ status: 'idle', txError: null, txHash: null });
 
   /** Resets transaction state back to idle. */
@@ -80,7 +82,7 @@ export function useRemoveLiquidity(position: PositionSnapshot | null, authToken:
       });
 
       const signResult = await signTransaction(xdr, {
-        networkPassphrase: SWYFT_NETWORK_PASSPHRASE,
+        networkPassphrase: getNetworkPassphrase(network),
       });
       const signedXdr = resolveSignedXdr(signResult);
 
@@ -117,7 +119,7 @@ export function useRemoveLiquidity(position: PositionSnapshot | null, authToken:
       });
 
       const signResult = await signTransaction(xdr, {
-        networkPassphrase: SWYFT_NETWORK_PASSPHRASE,
+        networkPassphrase: getNetworkPassphrase(network),
       });
       const signedXdr = resolveSignedXdr(signResult);
 

--- a/apps/web/hooks/useSwapExecution.ts
+++ b/apps/web/hooks/useSwapExecution.ts
@@ -1,11 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { signTransaction } from '@stellar/freighter-api';
 import { buildSwapTx, toRawAmount, toStellarAddress } from '@swyft/sdk';
 import type { SwapQuote } from '@swyft/sdk';
 import type { Token } from '@swyft/ui';
-import { API_BASE, SWYFT_NETWORK_PASSPHRASE } from '@/lib/constants';
+import { API_BASE, getNetworkPassphrase } from '@/lib/constants';
+import { useNetworkContext } from '@/context/NetworkContext';
+import { useTransactionStatus } from '@/context/TransactionStatusContext';
 
 export type SwapStatus = 'idle' | 'signing' | 'submitting' | 'success' | 'error';
 export type SwapError = 'rejected' | 'slippage' | 'network' | null;
@@ -25,12 +27,42 @@ interface ExecuteParams {
   walletAddress: string;
 }
 
+const ERROR_MESSAGES: Record<Exclude<SwapError, null>, string> = {
+  rejected: 'Swap rejected in wallet',
+  slippage: 'Price moved beyond slippage tolerance',
+  network: 'Network error — swap could not be submitted',
+};
+
 export function useSwapExecution() {
+  const { network } = useNetworkContext();
+  const { reportTx } = useTransactionStatus();
+  const labelRef = useRef('Swap');
   const [result, setResult] = useState<SwapResult>({
     status: 'idle',
     error: null,
     txHash: null,
   });
+
+  // Mirror local swap status into the app-wide indicator so it stays
+  // visible even after the confirmation modal closes. 'idle' also covers
+  // a silent wallet-rejection, which must clear a stuck "signing" pill.
+  useEffect(() => {
+    if (result.status === 'idle') {
+      reportTx(null);
+      return;
+    }
+    if (result.status === 'success' || result.status === 'error') {
+      reportTx({
+        label: labelRef.current,
+        status: result.status,
+        txHash: result.txHash,
+        errorMessage: result.error ? ERROR_MESSAGES[result.error] : undefined,
+      });
+      return;
+    }
+    reportTx({ label: labelRef.current, status: result.status, txHash: null });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result.status, result.txHash, result.error]);
 
   function reset() {
     setResult({ status: 'idle', error: null, txHash: null });
@@ -39,6 +71,7 @@ export function useSwapExecution() {
   async function execute(params: ExecuteParams) {
     const { poolId, tokenIn, tokenOut, amountIn, quote, walletAddress } = params;
 
+    labelRef.current = `${tokenIn.symbol} → ${tokenOut.symbol} swap`;
     setResult({ status: 'signing', error: null, txHash: null });
 
     try {
@@ -52,7 +85,7 @@ export function useSwapExecution() {
       });
 
       const signResult = await signTransaction(xdr, {
-        networkPassphrase: SWYFT_NETWORK_PASSPHRASE,
+        networkPassphrase: getNetworkPassphrase(network),
       });
       const signedXdr =
         typeof signResult === 'string'

--- a/apps/web/hooks/useWallet.ts
+++ b/apps/web/hooks/useWallet.ts
@@ -9,7 +9,7 @@ import {
   signTransaction as freighterSignTx,
 } from '@stellar/freighter-api';
 import { useState, useEffect, useCallback } from 'react';
-import { SWYFT_NETWORK, WALLET_STORAGE_KEY } from '@/lib/constants';
+import { SWYFT_NETWORK, WALLET_STORAGE_KEY, type StellarNetwork } from '@/lib/constants';
 
 export type WalletError = 'NOT_INSTALLED' | 'REJECTED' | 'WRONG_NETWORK' | null;
 
@@ -24,24 +24,32 @@ export interface WalletState {
   signTransaction: (xdr: string) => Promise<string>;
 }
 
-export function useWallet(): WalletState {
+/**
+ * @param targetNetwork - Network the connected wallet is expected to be on.
+ *   Defaults to the build-time env network; pass the live selection from
+ *   `useNetworkContext()` to validate against the user's runtime choice.
+ */
+export function useWallet(targetNetwork: StellarNetwork = SWYFT_NETWORK): WalletState {
   const [address, setAddress] = useState<string | null>(null);
   const [error, setError] = useState<WalletError>(null);
   const [connecting, setConnecting] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  const validateAndSet = useCallback(async (addr: string) => {
-    const networkResult = await getNetwork();
-    const network = 'network' in networkResult ? networkResult.network : networkResult;
-    if ((network as string).toUpperCase() !== SWYFT_NETWORK) {
-      setError('WRONG_NETWORK');
-      return false;
-    }
-    setAddress(addr);
-    localStorage.setItem(WALLET_STORAGE_KEY, addr);
-    setError(null);
-    return true;
-  }, []);
+  const validateAndSet = useCallback(
+    async (addr: string) => {
+      const networkResult = await getNetwork();
+      const network = 'network' in networkResult ? networkResult.network : networkResult;
+      if ((network as string).toUpperCase() !== targetNetwork) {
+        setError('WRONG_NETWORK');
+        return false;
+      }
+      setAddress(addr);
+      localStorage.setItem(WALLET_STORAGE_KEY, addr);
+      setError(null);
+      return true;
+    },
+    [targetNetwork]
+  );
 
   // Restore session on mount
   useEffect(() => {

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,15 +1,27 @@
+export type StellarNetwork = 'TESTNET' | 'PUBLIC';
+
+/** Build-time default network, sourced from the environment. */
 export const SWYFT_NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'TESTNET') as
   | 'TESTNET'
   | 'PUBLIC';
-export const SWYFT_NETWORK_PASSPHRASE =
-  SWYFT_NETWORK === 'PUBLIC'
-    ? 'Public Global Stellar Network ; September 2015'
-    : 'Test SDF Network ; September 2015';
+export const SWYFT_NETWORK_PASSPHRASE = getNetworkPassphrase(SWYFT_NETWORK);
 export const WALLET_STORAGE_KEY = 'swyft_wallet_address';
+/** localStorage key for the user's runtime testnet/mainnet selection. */
+export const NETWORK_STORAGE_KEY = 'swyft_selected_network';
 export const API_BASE = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'}/v1`;
 
-export function explorerTxUrl(hash: string): string {
-  return SWYFT_NETWORK === 'PUBLIC'
+export function isStellarNetwork(value: unknown): value is StellarNetwork {
+  return value === 'TESTNET' || value === 'PUBLIC';
+}
+
+export function getNetworkPassphrase(network: StellarNetwork): string {
+  return network === 'PUBLIC'
+    ? 'Public Global Stellar Network ; September 2015'
+    : 'Test SDF Network ; September 2015';
+}
+
+export function getExplorerTxUrl(hash: string, network: StellarNetwork = SWYFT_NETWORK): string {
+  return network === 'PUBLIC'
     ? `https://stellar.expert/explorer/public/tx/${hash}`
     : `https://stellar.expert/explorer/testnet/tx/${hash}`;
 }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.1.0] - Unreleased
 
 ### Added
+- Per-module subpath exports (`@swyft/sdk/quote`, `/liquidity`, `/queries`, `/swap`, `/types`, `/config`) alongside the root `@swyft/sdk` barrel, so bundlers only pull in the code that's actually imported.
+- Explicit `browser` / `import` / `require` conditions on every entrypoint so browser bundlers and Node (ESM and CJS) resolve the correct build without extra configuration.
 - Initial public release of `@swyft/sdk`.
 - `buildSwapTx` — build unsigned single-hop Soroban swap transactions.
 - `calculateSwapQuote` — off-chain constant-product swap estimation.
@@ -19,3 +21,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Dual CJS/ESM build via `tsup` with TypeScript declaration files.
 - Published to npm registry as `@swyft/sdk` (public, scoped package).
 - Automated publish workflow (`.github/workflows/publish-sdk.yml`) triggered on `sdk/v*` tags.
+
+### Fixed
+- `package.json`'s `module`/`types`/`exports` fields pointed at `.js`/`.d.ts` file names, but the ESM and declaration builds actually emit `.mjs`/`.d.mts` (tsup's default extensions for a package without `"type": "module"`). This silently broke `import`/`types` resolution for any consumer that resolved the built `dist/` output rather than the workspace source. Paths now match the real build output.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -107,12 +107,32 @@ console.log(tx.xdr);
 
 ---
 
+## Tree-shaking & entrypoints
+
+Every submodule is published as its own subpath export, so a bundler only
+includes the code your app actually imports:
+
+```ts
+import { buildSwapTx } from '@swyft/sdk';        // full barrel — still tree-shakeable
+import { buildSwapTx } from '@swyft/sdk/swap';    // same function, narrower import graph
+```
+
+Available subpaths: `@swyft/sdk/quote`, `@swyft/sdk/liquidity`, `@swyft/sdk/queries`,
+`@swyft/sdk/swap`, `@swyft/sdk/types`, `@swyft/sdk/config`.
+
+The package sets `"sideEffects": false` and ships separate `browser` / `import`
+(ESM) / `require` (CJS) conditions per entrypoint, so browser bundlers (webpack,
+Vite, esbuild, Next.js/Turbopack) and Node (both `require` and native `import`)
+each resolve the correct build automatically — no manual configuration needed.
+
+---
+
 ## Advanced: On-chain Quote Simulation
 
 For a precise quote that accounts for the full tick ladder, use `getSwapQuote` from the quote module:
 
 ```ts
-import { getSwapQuote } from '@swyft/sdk/dist/esm/quote';
+import { getSwapQuote } from '@swyft/sdk/quote';
 import { getPool } from '@swyft/sdk';
 
 const poolState = await getPool({ rpcUrl: 'https://soroban-testnet.stellar.org', poolAddress: 'CPOOL...' });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,14 +20,53 @@
     "directory": "packages/sdk"
   },
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "module": "./dist/esm/index.mjs",
+  "browser": "./dist/esm/index.mjs",
+  "types": "./dist/types/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.mts",
+      "browser": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "./quote": {
+      "types": "./dist/types/quote.d.mts",
+      "browser": "./dist/esm/quote.mjs",
+      "import": "./dist/esm/quote.mjs",
+      "require": "./dist/cjs/quote.js"
+    },
+    "./liquidity": {
+      "types": "./dist/types/liquidity.d.mts",
+      "browser": "./dist/esm/liquidity.mjs",
+      "import": "./dist/esm/liquidity.mjs",
+      "require": "./dist/cjs/liquidity.js"
+    },
+    "./queries": {
+      "types": "./dist/types/queries.d.mts",
+      "browser": "./dist/esm/queries.mjs",
+      "import": "./dist/esm/queries.mjs",
+      "require": "./dist/cjs/queries.js"
+    },
+    "./swap": {
+      "types": "./dist/types/swap.d.mts",
+      "browser": "./dist/esm/swap.mjs",
+      "import": "./dist/esm/swap.mjs",
+      "require": "./dist/cjs/swap.js"
+    },
+    "./types": {
+      "types": "./dist/types/types.d.mts",
+      "browser": "./dist/esm/types.mjs",
+      "import": "./dist/esm/types.mjs",
+      "require": "./dist/cjs/types.js"
+    },
+    "./config": {
+      "types": "./dist/types/config.d.mts",
+      "browser": "./dist/esm/config.mjs",
+      "import": "./dist/esm/config.mjs",
+      "require": "./dist/cjs/config.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from 'tsup';
 
+// Each submodule gets its own entry so consumers can either import the
+// `.` barrel or reach a single module directly (e.g. `@swyft/sdk/swap`).
+// Subpath imports guarantee unused modules never enter the bundle, even
+// under bundlers/runtimes that don't tree-shake a barrel file well (or
+// CJS `require`, which can't tree-shake at all).
+const entry = {
+  index: 'src/index.ts',
+  quote: 'src/quote.ts',
+  liquidity: 'src/liquidity.ts',
+  queries: 'src/queries.ts',
+  swap: 'src/swap.ts',
+  types: 'src/types.ts',
+  config: 'src/config.ts',
+};
+
 export default defineConfig([
   // ESM build
   {
-    entry: { index: 'src/index.ts' },
+    entry,
     format: ['esm'],
     dts: false,
     outDir: 'dist/esm',
@@ -18,7 +33,7 @@ export default defineConfig([
   },
   // CJS build
   {
-    entry: { index: 'src/index.ts' },
+    entry,
     format: ['cjs'],
     dts: false,
     outDir: 'dist/cjs',
@@ -33,7 +48,7 @@ export default defineConfig([
   },
   // Type declarations only
   {
-    entry: { index: 'src/index.ts' },
+    entry,
     format: ['esm'],
     dts: { only: true },
     outDir: 'dist/types',


### PR DESCRIPTION
## Summary

**Web — testnet/mainnet network switcher (#485)**
- New `NetworkContext` persists the user's testnet/mainnet choice to `localStorage`, falling back to the env default and discarding a corrupted/unrecognized stored value instead of breaking.
- New `NetworkSwitcher` control in the navbar. Switching networks while a wallet is connected disconnects it first, since a session validated against the old network can no longer be trusted.
- `useWallet`, `useSwapExecution`, `useRemoveLiquidity`, `SwapConfirmModal`, and the portfolio page now sign transactions and build explorer links against the live selected network instead of the build-time env constant, so the switch actually affects wallet validation, signing, and "view transaction" links at runtime — not just a label.
- `lib/constants.ts` gains network-parameterized `getNetworkPassphrase`/`getExplorerTxUrl` helpers; the now-superseded `explorerTxUrl` helper was removed since nothing calls it anymore.

**Web — transaction pending spinner UX (#484)**
- New `TransactionStatusContext` + a navbar-level `TransactionStatusIndicator` that mirrors swap status (signing/submitting/success/error) so it stays visible after the confirmation modal closes. Previously the modal's `onSuccess` callback closed it the instant status flipped to "success", so the success screen never really had a chance to be seen and there was no lasting confirmation once it closed.
- Clears itself on a silent wallet rejection (previously left a stuck "waiting for signature" spinner), and success/error toasts auto-dismiss after 12s or can be dismissed manually.

**SDK — tree-shakeable subpath exports (#487) and browser/node entrypoints (#486)**
- Split the `tsup` build into per-module entries (`quote`, `liquidity`, `queries`, `swap`, `types`, `config`) alongside the existing barrel, and published each as its own `package.json` subpath export (e.g. `@swyft/sdk/swap`) with explicit `browser`/`import`/`require` conditions, so bundlers only pull in the submodules an app actually imports and Node's native ESM resolver gets a correct entrypoint instead of relying solely on `main`/`module` fallthrough.
- While verifying the new exports map against a real build, found that `package.json`'s `module`/`types`/`exports` fields pointed at `.js`/`.d.ts` file names, but `tsup` (no `"type": "module"` in this package) actually emits `.mjs`/`.d.mts` for the ESM and declaration builds. That mismatch would have broken `import`/`types` resolution for any real consumer of the published `dist` output; paths are corrected to match `tsup`'s actual output.
- README/CHANGELOG updated to document the new subpath imports and fix a stale deep-import example (`@swyft/sdk/dist/esm/quote` → `@swyft/sdk/quote`).

## Test plan
- [x] SDK: `tsup` build verified locally — all seven entries (barrel + 6 submodules) emit correctly for ESM, CJS, and `.d.mts` types.
- [x] SDK: bundled a snippet importing a single export through both the barrel and a subpath with `esbuild`; confirmed tree-shaking drops unrelated code (e.g. the RPC query helpers) in both cases.
- [x] Web: `vitest run` — no regressions. Every failing test/file was independently reproduced against unmodified `main` in this sandbox (missing local API server for un-mocked `fetch` calls, incomplete standalone package installs) — none are caused by this change.
- [x] Web: `tsc --noEmit` — no new type errors; pre-existing errors (missing jest-dom matcher types, unbuilt `packages/ui`, and an unrelated `ownerWallet` type gap in `useRemoveLiquidity`'s `collectFees`) all reproduce identically on unmodified `main`.

Closes #485
Closes #484
Closes #487
Closes #486