### PR TITLE
feat: add Dependabot, admin audit log, CSP headers, and dark mode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,94 @@
+version: 2
+
+updates:
+  # ── NestJS / npm (monorepo root) ──────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+        update-types:
+          - minor
+          - patch
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Major NestJS upgrades require manual review
+      - dependency-name: "@nestjs/*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "chore"
+      include: scope
+
+  # ── NestJS API app ────────────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /apps/api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "@nestjs/*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "chore"
+      include: scope
+
+  # ── Next.js web app ───────────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore"
+      include: scope
+
+  # ── GitHub Actions ────────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore"
+      include: scope

--- a/apps/api/src/admin/admin-audit.interceptor.ts
+++ b/apps/api/src/admin/admin-audit.interceptor.ts
@@ -1,0 +1,67 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, tap } from 'rxjs';
+import { Request, Response } from 'express';
+import { AdminAuditService } from './admin-audit.service';
+import { createHash } from 'crypto';
+
+/**
+ * Fires after every admin controller action and writes an immutable entry to
+ * the admin_audit_log table. The internal API key is one-way hashed before
+ * storage so the raw secret is never persisted.
+ */
+@Injectable()
+export class AdminAuditInterceptor implements NestInterceptor {
+  constructor(private readonly auditService: AdminAuditService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
+
+    const rawKey = req.headers['x-internal-key'] as string | undefined;
+    const actor = rawKey
+      ? createHash('sha256').update(rawKey).digest('hex').slice(0, 16)
+      : 'unknown';
+
+    const action = `${req.method} ${req.path}`;
+    const resource = req.path.split('/').filter(Boolean)[1] ?? 'admin';
+
+    const meta: Record<string, unknown> = {};
+    if (req.query && Object.keys(req.query).length > 0) {
+      meta['query'] = req.query;
+    }
+
+    return next.handle().pipe(
+      tap({
+        next: () => {
+          void this.auditService.log({
+            actor,
+            action,
+            resource,
+            meta,
+            ip: req.ip,
+            statusCode: res.statusCode,
+          });
+        },
+        error: (err: unknown) => {
+          const status =
+            err && typeof err === 'object' && 'status' in err
+              ? (err as { status: number }).status
+              : 500;
+          void this.auditService.log({
+            actor,
+            action,
+            resource,
+            meta: { ...meta, error: true },
+            ip: req.ip,
+            statusCode: status,
+          });
+        },
+      }),
+    );
+  }
+}

--- a/apps/api/src/admin/admin-audit.service.ts
+++ b/apps/api/src/admin/admin-audit.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface AdminAuditEntry {
+  actor: string;
+  action: string;
+  resource: string;
+  meta?: Record<string, unknown>;
+  ip?: string;
+  statusCode?: number;
+}
+
+@Injectable()
+export class AdminAuditService {
+  private readonly logger = new Logger(AdminAuditService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Persist an immutable audit entry for an admin API action.
+   * Failures are caught and logged so they never interrupt the request.
+   */
+  async log(entry: AdminAuditEntry): Promise<void> {
+    try {
+      await this.prisma.adminAuditLog.create({
+        data: {
+          actor: entry.actor,
+          action: entry.action,
+          resource: entry.resource,
+          meta: JSON.stringify(entry.meta ?? {}),
+          ip: entry.ip ?? null,
+          statusCode: entry.statusCode ?? null,
+        },
+      });
+    } catch (err) {
+      // Audit logging must never break the request.
+      this.logger.error('Failed to write admin audit log', err);
+    }
+  }
+
+  /**
+   * Retrieve recent audit log entries. Used by the /admin/audit endpoint.
+   */
+  async findRecent(limit = 100, offset = 0) {
+    return this.prisma.adminAuditLog.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(limit, 500),
+      skip: offset,
+      select: {
+        id: true,
+        actor: true,
+        action: true,
+        resource: true,
+        meta: true,
+        ip: true,
+        statusCode: true,
+        createdAt: true,
+      },
+    });
+  }
+}

--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -2,11 +2,19 @@ import { Module } from '@nestjs/common';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
 import { AnalyticsScheduler } from './analytics.scheduler';
+import { AdminAuditService } from './admin-audit.service';
+import { AdminAuditInterceptor } from './admin-audit.interceptor';
 import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],
   controllers: [AnalyticsController],
-  providers: [AnalyticsService, AnalyticsScheduler],
+  providers: [
+    AnalyticsService,
+    AnalyticsScheduler,
+    AdminAuditService,
+    AdminAuditInterceptor,
+  ],
+  exports: [AdminAuditService],
 })
 export class AdminModule {}

--- a/apps/api/src/admin/analytics.controller.spec.ts
+++ b/apps/api/src/admin/analytics.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
+import { AdminAuditService } from './admin-audit.service';
+import { AdminAuditInterceptor } from './admin-audit.interceptor';
 import { InternalKeyGuard } from './internal-key.guard';
 
 const mockService = {
@@ -8,6 +10,11 @@ const mockService = {
   getTvl: jest.fn().mockResolvedValue({ interval: '7d', series: [] }),
   getVolume: jest.fn().mockResolvedValue({ interval: '7d', series: [] }),
   getFees: jest.fn().mockResolvedValue({ byPool: [] }),
+};
+
+const mockAuditService = {
+  log: jest.fn().mockResolvedValue(undefined),
+  findRecent: jest.fn().mockResolvedValue([]),
 };
 
 describe('AnalyticsController', () => {
@@ -19,6 +26,8 @@ describe('AnalyticsController', () => {
       controllers: [AnalyticsController],
       providers: [
         { provide: AnalyticsService, useValue: mockService },
+        { provide: AdminAuditService, useValue: mockAuditService },
+        { provide: AdminAuditInterceptor, useValue: { intercept: (_: unknown, next: { handle: () => unknown }) => next.handle() } },
         { provide: InternalKeyGuard, useValue: { canActivate: () => true } },
       ],
     }).compile();
@@ -65,5 +74,23 @@ describe('AnalyticsController', () => {
 
     expect(mockService.getFees).toHaveBeenCalled();
     expect(result).toEqual({ byPool: [{ poolId: 'p1', feesAmount0: '10', feesAmount1: '20' }] });
+  });
+
+  it('returns audit log entries with defaults', async () => {
+    const entries = [{ id: '1', actor: 'abc', action: 'GET /admin/analytics/overview', resource: 'analytics', meta: '{}', ip: null, statusCode: 200, createdAt: new Date() }];
+    mockAuditService.findRecent.mockResolvedValue(entries);
+
+    const result = await controller.getAuditLog(undefined, undefined);
+
+    expect(mockAuditService.findRecent).toHaveBeenCalledWith(100, 0);
+    expect(result).toEqual(entries);
+  });
+
+  it('passes limit and offset to audit service', async () => {
+    mockAuditService.findRecent.mockResolvedValue([]);
+
+    await controller.getAuditLog('50', '10');
+
+    expect(mockAuditService.findRecent).toHaveBeenCalledWith(50, 10);
   });
 });

--- a/apps/api/src/admin/analytics.controller.ts
+++ b/apps/api/src/admin/analytics.controller.ts
@@ -1,33 +1,65 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { AnalyticsService } from './analytics.service';
+import { AdminAuditService } from './admin-audit.service';
+import { AdminAuditInterceptor } from './admin-audit.interceptor';
 import { InternalKeyGuard } from './internal-key.guard';
 import { TimeSeriesQueryDto } from './dto/analytics-query.dto';
 import { SWAGGER_TAGS } from '../swagger.constants';
 
 @ApiTags(SWAGGER_TAGS.ADMIN)
-@Controller('admin/analytics')
+@Controller('admin')
 @UseGuards(InternalKeyGuard)
+@UseInterceptors(AdminAuditInterceptor)
 export class AnalyticsController {
-  constructor(private readonly analytics: AnalyticsService) {}
+  constructor(
+    private readonly analytics: AnalyticsService,
+    private readonly auditService: AdminAuditService,
+  ) {}
 
-  @Get('overview')
+  @Get('analytics/overview')
+  @ApiOperation({ summary: 'Protocol overview metrics' })
   getOverview() {
     return this.analytics.getOverview();
   }
 
-  @Get('tvl')
+  @Get('analytics/tvl')
+  @ApiOperation({ summary: 'TVL time series' })
   getTvl(@Query() query: TimeSeriesQueryDto) {
     return this.analytics.getTvl(query.interval!);
   }
 
-  @Get('volume')
+  @Get('analytics/volume')
+  @ApiOperation({ summary: 'Volume time series' })
   getVolume(@Query() query: TimeSeriesQueryDto) {
     return this.analytics.getVolume(query.interval!);
   }
 
-  @Get('fees')
+  @Get('analytics/fees')
+  @ApiOperation({ summary: 'Fees collected per pool' })
   getFees() {
     return this.analytics.getFees();
+  }
+
+  // ── Audit log ────────────────────────────────────────────────────────────
+
+  @Get('audit')
+  @ApiOperation({ summary: 'Recent admin API audit log entries' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  getAuditLog(
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.auditService.findRecent(
+      limit ? parseInt(limit, 10) : 100,
+      offset ? parseInt(offset, 10) : 0,
+    );
   }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+/* Enable class-based dark mode so the `dark:` variant responds to the
+   `dark` class on <html> (set by the layout.tsx inline script) rather than
+   only the OS media query. The media-query fallback remains for browsers
+   where JS is unavailable. */
+@variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -17,6 +23,11 @@
     --background: #0a0a0a;
     --foreground: #ededed;
   }
+}
+
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -35,6 +35,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+      <head>
+        {/* Inline script to apply the `dark` class before first paint,
+            preventing a flash of unstyled content in dark mode. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{if(window.matchMedia('(prefers-color-scheme: dark)').matches){document.documentElement.classList.add('dark');}}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body className="min-h-full flex flex-col">
         <Providers>
           <WalletProvider>

--- a/apps/web/components/PriceChart.tsx
+++ b/apps/web/components/PriceChart.tsx
@@ -149,7 +149,11 @@ export function PriceChart({ tokenA, tokenB, tokenASymbol, tokenBSymbol }: Props
   const [isDark, setIsDark] = useState(false);
 
   useEffect(() => {
-    setIsDark(window.matchMedia('(prefers-color-scheme: dark)').matches);
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    setIsDark(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
   }, []);
 
   const redraw = useCallback(() => {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,81 @@
 import type { NextConfig } from 'next';
 import path from 'path';
 
+/**
+ * Content-Security-Policy for the Swyft web app.
+ *
+ * Policy rationale:
+ *  - default-src 'self'        — deny everything not explicitly permitted
+ *  - script-src  'self' 'unsafe-inline'
+ *                              — Next.js inline scripts (hydration, font loader)
+ *                                require 'unsafe-inline'; nonce-based CSP is not
+ *                                yet wired to the Next.js runtime here.
+ *  - style-src   'self' 'unsafe-inline'
+ *                              — Tailwind CSS and Radix UI inject inline styles.
+ *  - img-src     'self' data: blob: https:
+ *                              — Token logos are fetched from third-party CDNs;
+ *                                blob: is needed for canvas toDataURL exports.
+ *  - font-src    'self' https://fonts.gstatic.com
+ *                              — Geist font served via Google Fonts CDN.
+ *  - connect-src 'self' https: wss:
+ *                              — Soroban RPC, Horizon, and the Swyft WebSocket feed.
+ *  - frame-ancestors 'none'   — Prevents the app from being iframed (clickjacking).
+ *  - object-src  'none'       — Disallow Flash and similar plugins.
+ *  - base-uri    'self'       — Prevent base-tag injection.
+ */
+const ContentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https: wss:",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+]
+  .join('; ')
+  .trim();
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy,
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];
+
 const nextConfig: NextConfig = {
   turbopack: {
     root: path.join(__dirname, '../..'),
+  },
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 

--- a/prisma/migrations/20260724000000_add_admin_audit_log/migration.sql
+++ b/prisma/migrations/20260724000000_add_admin_audit_log/migration.sql
@@ -1,0 +1,17 @@
+-- #497 Audit log for admin API actions
+CREATE TABLE "admin_audit_log" (
+    "id"         TEXT         NOT NULL,
+    "actor"      TEXT         NOT NULL,
+    "action"     TEXT         NOT NULL,
+    "resource"   TEXT         NOT NULL,
+    "meta"       TEXT         NOT NULL DEFAULT '{}',
+    "ip"         TEXT,
+    "statusCode" INTEGER,
+    "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_audit_log_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "admin_audit_log_actor_idx"     ON "admin_audit_log"("actor");
+CREATE INDEX "admin_audit_log_action_idx"    ON "admin_audit_log"("action");
+CREATE INDEX "admin_audit_log_createdAt_idx" ON "admin_audit_log"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -268,6 +268,28 @@ model WebhookAuditLog {
   @@map("webhook_audit_log")
 }
 
+// #497 — Audit log for admin API actions
+/// Immutable record of every action performed via the /admin/* endpoints.
+model AdminAuditLog {
+  id         String   @id @default(cuid())
+  /// Identifier of the caller — the value of the x-internal-key header (hashed) or 'system'.
+  actor      String
+  /// HTTP method + route, e.g. "GET /admin/analytics/overview".
+  action     String
+  /// High-level resource label, e.g. "analytics", "pools".
+  resource   String
+  /// JSON snapshot of relevant request context (query params, body summary).
+  meta       String   @default("{}")
+  ip         String?
+  statusCode Int?
+  createdAt  DateTime @default(now())
+
+  @@index([actor])
+  @@index([action])
+  @@index([createdAt])
+  @@map("admin_audit_log")
+}
+
 /// Dead letter queue for failed indexer events that exceeded max retries
 model IndexerDeadLetter {
   id           String   @id @default(cuid())


### PR DESCRIPTION
## Summary of Changes
This PR implements four platform improvements:

### #496 - Dependabot for NestJS upgrades
- Added .github/dependabot.yml with scheduled weekly updates

### #497 - Audit log for admin API actions
- Created AdminAuditLog Prisma model and migration
- Added AdminAuditService and AdminAuditInterceptor
- Extended AnalyticsController with audit log query endpoint

### #498 - CSP headers on web app
- Added comprehensive Content-Security-Policy to next.config.ts
- Includes strict security headers

### #499 - Dark mode on price chart
- Updated PriceChart.tsx with matchMedia listener
- Added Tailwind v4 class-based dark mode support
- Added FOUC prevention script in layout.tsx

All changes follow existing repository patterns.

Closes #496
Closes #497
Closes #498
Closes #499
