### PR TITLE
Feature/frontend multi issue

### DIFF
--- a/apps/web/components/TransactionHistory.tsx
+++ b/apps/web/components/TransactionHistory.tsx
@@ -148,6 +148,7 @@ export function TransactionHistory({ walletAddress }: TransactionHistoryProps) {
             getExplorerUrl={getExplorerUrl}
             formatDate={formatDate}
             truncateHash={truncateHash}
+            cols={7}
           />
         ) : (
           <LpTable
@@ -194,6 +195,7 @@ interface SwapTableProps {
   getExplorerUrl: (hash: string) => string;
   formatDate: (timestamp: number) => string;
   truncateHash: (hash: string) => string;
+  cols?: number;
 }
 
 function SkeletonRows({ cols }: { cols: number }) {
@@ -203,7 +205,7 @@ function SkeletonRows({ cols }: { cols: number }) {
         <tr key={i} aria-hidden="true">
           {Array.from({ length: cols }).map((__, j) => (
             <td key={j} className="py-3 px-4">
-              <div className="h-4 rounded bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+              <div className={`h-4 rounded ${j === 1 ? 'w-32' : 'w-full'} bg-zinc-200 dark:bg-zinc-700 animate-pulse`} />
             </td>
           ))}
         </tr>
@@ -219,6 +221,7 @@ function SwapTable({
   getExplorerUrl,
   formatDate,
   truncateHash,
+  cols = 7,
 }: SwapTableProps) {
   if (error) {
     return <div className="text-center py-8 text-red-500">Failed to load swaps</div>;
@@ -250,6 +253,9 @@ function SwapTable({
             <th className="text-left py-3 px-4 text-sm font-medium text-zinc-600 dark:text-zinc-400">
               Pair
             </th>
+            <th className="text-left py-3 px-4 text-sm font-medium text-zinc-600 dark:text-zinc-400">
+              Route
+            </th>
             <th className="text-right py-3 px-4 text-sm font-medium text-zinc-600 dark:text-zinc-400">
               Input
             </th>
@@ -269,7 +275,7 @@ function SwapTable({
         </thead>
         <tbody>
           {loading ? (
-            <SkeletonRows cols={6} />
+            <SkeletonRows cols={cols} />
           ) : (
             swaps.map((swap) => (
               <tr
@@ -278,6 +284,15 @@ function SwapTable({
               >
                 <td className="py-3 px-4 text-sm text-zinc-900 dark:text-zinc-100">
                   {swap.token0Symbol}/{swap.token1Symbol}
+                </td>
+                <td className="py-3 px-4 text-sm text-zinc-700 dark:text-zinc-300">
+                  {swap.routeLeg && swap.routeLeg.length > 0 ? (
+                    <span className="font-mono text-xs">
+                      {swap.routeLeg.join(' → ')}
+                    </span>
+                  ) : (
+                    <span className="text-zinc-400 dark:text-zinc-500">—</span>
+                  )}
                 </td>
                 <td className="py-3 px-4 text-sm text-right text-zinc-900 dark:text-zinc-100 font-mono">
                   {swap.amount0}

--- a/apps/web/components/WebhooksPanel.tsx
+++ b/apps/web/components/WebhooksPanel.tsx
@@ -28,6 +28,9 @@ function SkeletonRow() {
       <td className="px-4 py-3">
         <div className="h-4 w-12 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
       </td>
+      <td className="px-4 py-3">
+        <div className="h-4 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </td>
       <td className="px-4 py-3 text-right">
         <div className="ml-auto h-7 w-16 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-700" />
       </td>
@@ -183,6 +186,7 @@ export function WebhooksPanel({ authToken }: WebhooksPanelProps) {
               <th className="px-4 py-3 text-left font-medium text-zinc-500">URL</th>
               <th className="px-4 py-3 text-left font-medium text-zinc-500">Events</th>
               <th className="px-4 py-3 text-left font-medium text-zinc-500">Status</th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-500">Last Delivery</th>
               <th className="px-4 py-3" />
             </tr>
           </thead>
@@ -195,7 +199,7 @@ export function WebhooksPanel({ authToken }: WebhooksPanelProps) {
             {/* Empty state */}
             {!loading && items.length === 0 && (
               <tr>
-                <td colSpan={4} className="px-4 py-12 text-center text-zinc-400 dark:text-zinc-600">
+                <td colSpan={5} className="px-4 py-12 text-center text-zinc-400 dark:text-zinc-600">
                   No webhooks registered yet. Click{' '}
                   <strong className="font-medium text-zinc-600 dark:text-zinc-400">Register</strong>{' '}
                   to add your first endpoint.
@@ -233,6 +237,38 @@ export function WebhooksPanel({ authToken }: WebhooksPanelProps) {
                     <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
                       Active
                     </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-sm">
+                  {!item.lastDeliveryStatus ? (
+                    <span className="text-zinc-400 dark:text-zinc-500">Never delivered</span>
+                  ) : item.lastDeliveryStatus === 'success' ? (
+                    <div className="flex flex-col gap-0.5">
+                      <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400 inline-block w-fit">
+                        Success
+                      </span>
+                      {item.lastDeliveryTimestamp && (
+                        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                          {new Date(item.lastDeliveryTimestamp * 1000).toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-0.5">
+                      <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-600 dark:bg-red-950 dark:text-red-400 inline-block w-fit">
+                        Failed
+                      </span>
+                      {item.lastDeliveryTimestamp && (
+                        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                          {new Date(item.lastDeliveryTimestamp * 1000).toLocaleString()}
+                        </span>
+                      )}
+                      {item.lastDeliveryError && (
+                        <span className="text-xs text-red-500 dark:text-red-400 truncate" title={item.lastDeliveryError}>
+                          {item.lastDeliveryError}
+                        </span>
+                      )}
+                    </div>
                   )}
                 </td>
                 <td className="px-4 py-3 text-right">

--- a/apps/web/hooks/useSwapQuote.ts
+++ b/apps/web/hooks/useSwapQuote.ts
@@ -29,6 +29,8 @@ export function useSwapQuote({ poolId, tokenInId, tokenOutId, amountIn, slippage
   const [quote, setQuote] = useState<SwapQuote | null>(null);
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const sequenceRef = useRef(0);
 
   // Recalculate quote whenever inputs change (debounced)
   useEffect(() => {
@@ -40,10 +42,15 @@ export function useSwapQuote({ poolId, tokenInId, tokenOutId, amountIn, slippage
 
     setLoading(true);
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (abortControllerRef.current) abortControllerRef.current.abort();
+
+    const currentSequence = ++sequenceRef.current;
 
     debounceRef.current = setTimeout(() => {
       const result = calculateSwapQuote({ poolId, tokenInId, tokenOutId, amountIn, slippageBps });
-      setQuote(result);
+      if (currentSequence === sequenceRef.current) {
+        setQuote(result);
+      }
       setLoading(false);
     }, DEBOUNCE_MS);
 

--- a/apps/web/hooks/useSwaps.ts
+++ b/apps/web/hooks/useSwaps.ts
@@ -14,6 +14,7 @@ export interface SwapSnapshot {
   txHash: string;
   walletAddress: string;
   timestamp: number;
+  routeLeg?: string[] | null;
 }
 
 export interface SwapsListResponse {

--- a/apps/web/hooks/useWebhooks.ts
+++ b/apps/web/hooks/useWebhooks.ts
@@ -9,6 +9,9 @@ export interface WebhookItem {
   eventTypes: string[];
   disabled: boolean;
   createdAt: string;
+  lastDeliveryStatus?: 'success' | 'failed' | null;
+  lastDeliveryTimestamp?: number | null;
+  lastDeliveryError?: string | null;
 }
 
 export function useWebhooks(authToken: string | null) {

--- a/packages/ui/src/TokenSelectorModal.tsx
+++ b/packages/ui/src/TokenSelectorModal.tsx
@@ -104,6 +104,20 @@ export function TokenSelectorModal({
       e.preventDefault();
       if (idx <= 0) inputRef.current?.focus();
       else items[idx - 1]?.focus();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+    }
+  }
+
+  function handleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const items = document.querySelectorAll<HTMLButtonElement>('button[data-token]');
+      items[0]?.focus();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
     }
   }
 
@@ -153,6 +167,7 @@ export function TokenSelectorModal({
               placeholder="Search by name or symbol"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleInputKeyDown}
               disabled={loading}
               className="w-full rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Search tokens"


### PR DESCRIPTION
 ## Summary

   This PR addresses four frontend improvements: preventing quote race conditions, adding keyboard navigation to token selector, showing webhook
   delivery status, and displaying multi-hop swap routes in transaction history.

   ## Changes

   ### #541 — useSwapQuote cancels in-flight request on rapid input
   - Added sequence token to prevent stale quote responses from overwriting newer calculations
   - Ensures only the latest quote is applied when user types rapidly

   ### #542 — Token selector keyboard navigation
   - Enhanced keyboard support with Escape key handling from any focused element
   - Arrow navigation from search input to token list (ArrowDown)
   - Escape key to close dialog from both input and token buttons
   - Focus trap provided by Radix Dialog prevents tabbing outside

   ### #540 — WebhooksPanel shows last delivery status
   - Extended WebhookItem interface with delivery status, timestamp, and error message
   - Table displays success/failed status with localized timestamp
   - Shows error snippet for failed deliveries
   - Fallback to "Never delivered" for new webhooks

   ### #543 — History API includes route legs in swap DTO
   - Extended SwapSnapshot with optional routeLeg array for multi-hop paths
   - Transaction history displays route with arrow separator (e.g., USDC → USDT → XLM)
   - Fallback to dash (—) for single-hop or legacy data without route info

   ## Notes

   - Code-only delivery: no install/build/test/scripts run during implementation
   - Committer: Tukura11
   - All changes follow existing patterns and conventions in the codebase

   Closes #541, Closes #542, Closes #540, Closes #543