### PR TITLE
Docs/dx and eval spikes

### DIFF
--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -1,0 +1,22 @@
+# API Changelog (Breaking Changes)
+
+This file tracks breaking changes to the `apps/api` REST surface. Any change that alters a response shape, removes/renames a field or endpoint, or changes required request parameters must be logged here.
+
+## Format
+Each entry should include:
+- Date
+- Endpoint(s) affected
+- What changed and why
+- Migration notes for consumers
+
+## Unreleased
+
+_No breaking changes logged yet. Add entries above this line as they happen._
+
+---
+
+## How to use this file
+When making a breaking REST change in `apps/api`:
+1. Add a new dated entry to this changelog in the same PR as the change.
+2. Note any client-side (`apps/web`) updates required and whether they're included in the same PR.
+3. If the change affects external/third-party consumers, call that out explicitly.

--- a/docs/DEPLOY_API.md
+++ b/docs/DEPLOY_API.md
@@ -1,0 +1,32 @@
+# Deploying apps/api: Blue/Green vs Rolling, and Migration Order
+
+This doc captures the deployment strategy notes for `apps/api`, including how DB migrations should be sequenced relative to the deploy.
+
+## Strategy options
+
+### Blue/Green
+- Two full environments (blue = current, green = new). Traffic cuts over once green is verified healthy.
+- Pros: instant rollback (flip traffic back to blue), no mixed-version traffic during rollout.
+- Cons: requires double the infra during rollout, DB schema must be compatible with both versions simultaneously during the cutover window.
+
+### Rolling
+- Instances replaced gradually, old and new versions serve traffic side by side during the rollout.
+- Pros: cheaper (no duplicate full environment), simpler infra.
+- Cons: old and new API versions run concurrently against the same DB, so schema changes must be backward compatible for the whole rollout window.
+
+## Recommended migration order (either strategy)
+Because old and new code may briefly run against the same database (rolling), or the DB is shared across blue/green during cutover, migrations must be **backward compatible** with the previous API version until rollout completes:
+
+1. **Expand**: Add new columns/tables as nullable/optional, additive only. Deploy this migration first, before any code depends on it.
+2. **Deploy new API version**: New code can read/write new columns; old code ignores them safely.
+3. **Backfill**: Populate new columns for existing rows if needed, out of band.
+4. **Cutover**: Once the new version is fully rolled out (all instances, or blue/green traffic fully switched), deploy code that relies on the new schema being present everywhere.
+5. **Contract**: In a later, separate migration, drop old columns/tables only after confirming no running code path (including rollback targets) still references them.
+
+## Rollback notes
+- Blue/Green: rollback = flip traffic back to blue. Do **not** run the "contract" migration step until you're confident you won't need to roll back to a version that depends on the old schema.
+- Rolling: rollback = redeploy previous image. Same constraint — don't drop old columns until all instances are confirmed on the new version and rollback is no longer a concern.
+
+## Open items
+- [ ] Confirm which strategy (blue/green vs rolling) the current infra actually supports for `apps/api`.
+- [ ] Document the specific migration tooling/commands used (Prisma migrate deploy, etc.) alongside this ordering.

--- a/docs/GRAPHQL_VS_TRPC_SPIKE.md
+++ b/docs/GRAPHQL_VS_TRPC_SPIKE.md
@@ -1,0 +1,29 @@
+# SPIKE: GraphQL vs tRPC vs REST for Swyft
+
+## Goal
+Decide whether Swyft should move off REST for the `apps/api` <-> `apps/web` boundary, and if so, to GraphQL or tRPC.
+
+## Context
+Swyft currently uses REST between `apps/api` and `apps/web`, with types shared manually / via `CONTRACTS.md`. This spike captures the tradeoffs so we can make a deliberate call instead of drifting.
+
+## Options
+
+### Stay on REST
+- Pros: no migration cost, well understood, easy to version (see API changelog doc), works well with external consumers/webhooks.
+- Cons: manual type sync between client/server, more boilerplate for CRUD-heavy endpoints, no built-in query batching.
+
+### tRPC
+- Pros: end-to-end TypeScript types with zero codegen, fast DX since `apps/api` and `apps/web` are both TS in this monorepo, minimal runtime overhead.
+- Cons: tightly couples client/server TS types (harder for non-TS or external consumers), less ideal if we plan to expose a public API, ecosystem smaller than GraphQL/REST.
+
+### GraphQL
+- Pros: flexible querying for clients, strong tooling (codegen, introspection), good fit if multiple heterogeneous clients (web, mobile, third parties) need different data shapes.
+- Cons: higher setup/maintenance cost (schema, resolvers, N+1 handling), overkill if Swyft only has one first-party web client, steeper learning curve for contributors.
+
+## Recommendation (draft, for discussion)
+Given Swyft is a TypeScript monorepo with one first-party web client and REST is already used for external/webhook-style integrations, tRPC is likely the better fit for internal `apps/web` <-> `apps/api` calls, while keeping REST for any public/external-facing endpoints. GraphQL is probably not justified unless a second consumer (e.g. mobile) with divergent data needs shows up.
+
+## Next steps
+- [ ] Confirm whether any external/third-party consumers exist today that would be broken by moving internal calls off REST.
+- [ ] Prototype one tRPC router alongside existing REST routes to measure DX/migration cost.
+- [ ] Revisit this doc once a decision is made and link the follow-up PR here.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,27 @@
+# Onboarding: Getting web + api + db running quickly
+
+This doc is the fast path for a new contributor to get the full Swyft stack (web, api, db) running locally with minimal steps.
+
+## Prerequisites
+- Node.js + pnpm installed
+- Docker (for local Postgres via `docker-compose.yml`)
+
+## Quick start
+1. Clone the repo and install dependencies: `pnpm install`
+2. Copy environment files:
+   - `apps/api/.env.example` -> `apps/api/.env`
+   - `apps/web/.env.example` -> `apps/web/.env` (if present)
+3. Start the database: `docker-compose up -d`
+4. Run Prisma migrations/generate against the local db (see `prisma/` for schema).
+5. Start the API: `pnpm --filter api dev`
+6. Start the web app: `pnpm --filter web dev`
+
+## Notes
+- `docker-compose.yml` at the repo root brings up the local Postgres instance used by `apps/api`.
+- `prisma/` holds the schema shared by the API; run generate/migrate before starting `apps/api` for the first time.
+- See `CONTRIBUTING.md` for coding conventions and `docs/ARCHITECTURE.md` for how `apps/api` and `apps/web` fit together.
+
+## Open items to streamline further
+- [ ] Add a single `pnpm dev` (or `make dev`) script that boots db + api + web together.
+- [ ] Add a `.env.example` presence check/script so missing env vars fail fast with a clear message.
+- [ ] Confirm minimum Node/pnpm versions and pin them in `package.json` engines field.


### PR DESCRIPTION
closes #508
closes #509
closes #510
closes #511


Document blue/green or rolling deploy + migrate order for apps/api.

Maintain a changelog for breaking REST changes.
Optimize onboarding so web+api+db start quickly