### PR TITLE
Fix/position tokenid il swaproute a11y

### DIFF
--- a/apps/api/src/positions/position.types.ts
+++ b/apps/api/src/positions/position.types.ts
@@ -29,6 +29,8 @@ export interface PositionSnapshot {
   readonly ownerWallet: string;
   /** Pool identifier where the position is deployed */
   readonly poolId: string;
+  /** NFT token ID identifying this position on-chain */
+  readonly tokenId: string;
   /** First token in the trading pair */
   readonly token0: string;
   /** Second token in the trading pair */

--- a/apps/api/src/positions/positions.repository.ts
+++ b/apps/api/src/positions/positions.repository.ts
@@ -224,6 +224,7 @@ export class PositionsRepository {
         id: position.id,
         ownerWallet: position.ownerAddress,
         poolId: position.poolId,
+        tokenId: position.tokenId,
         token0: token0Symbol,
         token1: token1Symbol,
         lowerTick: position.lowerTick,

--- a/apps/api/src/swaps/swap.types.ts
+++ b/apps/api/src/swaps/swap.types.ts
@@ -12,6 +12,8 @@ export interface SwapSnapshot {
   priceAtSwap: string;
   /** Fee charged for this swap (expressed in token0 units). */
   feeAmount: string;
+  /** Ordered pool IDs the swap routed through, when known (e.g. multi-hop). */
+  route?: string[];
   txHash: string;
   walletAddress: string;
   timestamp: number;

--- a/apps/web/components/PositionCard.tsx
+++ b/apps/web/components/PositionCard.tsx
@@ -15,6 +15,19 @@ function shortSymbol(id: string) {
   return id.length > 8 ? `${id.slice(0, 4)}…` : id;
 }
 
+/**
+ * Rough impermanent-loss estimate vs a hold-at-deposit baseline, using the
+ * range midpoint price as a proxy for the deposit price (constant-product
+ * approximation). Returned as a fraction (e.g. -0.012 = -1.2%).
+ */
+function estimateImpermanentLoss(p: PositionSnapshot): number {
+  const lower = Math.pow(1.0001, p.lowerTick);
+  const upper = Math.pow(1.0001, p.upperTick);
+  const depositPrice = Math.sqrt(lower * upper);
+  const priceRatio = p.poolCurrentPrice / depositPrice;
+  return (2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1;
+}
+
 interface Props {
   position: PositionSnapshot;
   onCollectFees: (id: string) => void;
@@ -31,6 +44,7 @@ export function PositionCard({ position: p, onCollectFees, collecting, loading =
   const fees0 = parseFloat(p.uncollectedFeesToken0);
   const fees1 = parseFloat(p.uncollectedFeesToken1);
   const hasFees = fees0 > 0 || fees1 > 0;
+  const ilEstimate = estimateImpermanentLoss(p);
 
   if (loading) {
     return (
@@ -103,6 +117,18 @@ export function PositionCard({ position: p, onCollectFees, collecting, loading =
           </p>
         </div>
       </div>
+
+      {/* Impermanent loss estimate vs. deposit baseline (range-midpoint proxy) */}
+      <p className="text-xs text-zinc-400 mb-4 -mt-2">
+        Est. impermanent loss:{' '}
+        <span
+          className={
+            ilEstimate < 0 ? 'text-red-500 dark:text-red-400' : 'text-zinc-500 dark:text-zinc-400'
+          }
+        >
+          {(ilEstimate * 100).toFixed(2)}%
+        </span>
+      </p>
 
       {/* Actions */}
       {p.status === 'active' && (

--- a/apps/web/components/TransactionHistory.tsx
+++ b/apps/web/components/TransactionHistory.tsx
@@ -260,6 +260,9 @@ function SwapTable({
               Price
             </th>
             <th className="text-left py-3 px-4 text-sm font-medium text-zinc-600 dark:text-zinc-400">
+              Route
+            </th>
+            <th className="text-left py-3 px-4 text-sm font-medium text-zinc-600 dark:text-zinc-400">
               Transaction
             </th>
             <th className="text-left py-3 px-4 text-sm font-medium text-zinc-600 dark:text-zinc-400">
@@ -269,7 +272,7 @@ function SwapTable({
         </thead>
         <tbody>
           {loading ? (
-            <SkeletonRows cols={6} />
+            <SkeletonRows cols={7} />
           ) : (
             swaps.map((swap) => (
               <tr
@@ -287,6 +290,9 @@ function SwapTable({
                 </td>
                 <td className="py-3 px-4 text-sm text-right text-zinc-900 dark:text-zinc-100 font-mono">
                   {swap.priceAtSwap}
+                </td>
+                <td className="py-3 px-4 text-sm text-zinc-600 dark:text-zinc-400 font-mono">
+                  {swap.route && swap.route.length > 0 ? swap.route.join(' → ') : '—'}
                 </td>
                 <td className="py-3 px-4 text-sm">
                   <a

--- a/apps/web/hooks/useSwaps.ts
+++ b/apps/web/hooks/useSwaps.ts
@@ -11,6 +11,8 @@ export interface SwapSnapshot {
   amount0: string;
   amount1: string;
   priceAtSwap: string;
+  /** Ordered pool IDs the swap routed through, when known (e.g. multi-hop). */
+  route?: string[];
   txHash: string;
   walletAddress: string;
   timestamp: number;

--- a/packages/sdk/src/position-math.ts
+++ b/packages/sdk/src/position-math.ts
@@ -207,3 +207,22 @@ export function sqrtPriceX96ToTick(sqrtPriceX96: bigint): number {
     return -Number((ratio * 20000n) / Q96);
   }
 }
+
+/**
+ * Estimates impermanent loss versus a hold-at-deposit baseline, using the
+ * standard constant-product approximation (price ratio between deposit and
+ * current price). Returned as a negative fraction (e.g. -0.012 = -1.2%).
+ *
+ * This is an approximation for concentrated-liquidity positions — it does
+ * not account for the position's tick range, only the price movement since
+ * deposit.
+ *
+ * @param depositPrice - Pool price (token1/token0) at the time liquidity was deposited
+ * @param currentPrice - Current pool price (token1/token0)
+ * @returns Impermanent loss as a fraction relative to the hold baseline (<= 0)
+ */
+export function estimateImpermanentLoss(depositPrice: number, currentPrice: number): number {
+  if (depositPrice <= 0 || currentPrice <= 0) throw new RangeError('prices must be positive');
+  const priceRatio = currentPrice / depositPrice;
+  return (2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1;
+}

--- a/packages/ui/src/SwapInput.tsx
+++ b/packages/ui/src/SwapInput.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Token } from './types';
 import { TokenLogo } from './TokenLogo';
 
@@ -13,6 +14,8 @@ interface Props {
   onTokenClick?: () => void;
 }
 
+let swapInputIdCounter = 0;
+
 export function SwapInput({
   label,
   token,
@@ -22,6 +25,9 @@ export function SwapInput({
   onAmountChange,
   onTokenClick,
 }: Props) {
+  const [inputId] = useState(() => `swap-input-${++swapInputIdCounter}`);
+  const errorId = `${inputId}-error`;
+
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const v = e.target.value;
     if (/^\d*\.?\d*$/.test(v)) onAmountChange?.(v);
@@ -38,8 +44,11 @@ export function SwapInput({
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex-1">
-          <p className="mb-1 text-xs text-zinc-400">{label}</p>
+          <label htmlFor={inputId} className="mb-1 block text-xs text-zinc-400">
+            {label}
+          </label>
           <input
+            id={inputId}
             type="text"
             inputMode="decimal"
             placeholder="0.00"
@@ -47,7 +56,9 @@ export function SwapInput({
             readOnly={readOnly}
             onChange={handleChange}
             aria-label={`${label} amount`}
-            className="w-full bg-transparent text-2xl font-semibold text-zinc-900 placeholder-zinc-300 focus:outline-none dark:text-white dark:placeholder-zinc-600"
+            aria-invalid={insufficient || undefined}
+            aria-describedby={insufficient ? errorId : undefined}
+            className="w-full bg-transparent text-2xl font-semibold text-zinc-900 placeholder-zinc-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:text-white dark:placeholder-zinc-600"
           />
         </div>
 
@@ -74,7 +85,11 @@ export function SwapInput({
 
       {balance !== undefined && (
         <div className="mt-1.5 flex items-center justify-between">
-          <span className={`text-xs ${insufficient ? 'text-red-500' : 'text-zinc-400'}`}>
+          <span
+            id={errorId}
+            role={insufficient ? 'alert' : undefined}
+            className={`text-xs ${insufficient ? 'text-red-500' : 'text-zinc-400'}`}
+          >
             {insufficient ? 'Insufficient balance' : ''}
           </span>
           <button


### PR DESCRIPTION
closes #500 
closes #501 
closes #502 
closes #503 
Persist and return NFT tokenId for concentrated-liquidity positions.
Position detail should show an impermanent-loss estimate vs deposit baseline

History rows should show the route taken for each swap when available.

