### PR TITLE
Fix/pool search candle improvements

### DIFF
--- a/apps/api/src/candles/gap-fill.policy.ts
+++ b/apps/api/src/candles/gap-fill.policy.ts
@@ -1,0 +1,60 @@
+import { CandleInterval } from './candles.service';
+
+export interface OhlcvBucket {
+  timestamp: number;
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+  volume: string;
+}
+
+const INTERVAL_SECONDS: Record<CandleInterval, number> = {
+  '1m': 60,
+  '5m': 300,
+  '1h': 3600,
+  '1d': 86400,
+};
+
+/**
+ * Gap fill policy for missing candle buckets: a missing bucket is
+ * "flat filled" using the previous bucket's close price (open = high = low =
+ * close = last known close) with zero volume, signalling no trading activity
+ * occurred rather than interpolating a price change. Leading gaps (no prior
+ * bucket exists yet) are left unfilled since there is no known price to carry
+ * forward.
+ */
+export function fillCandleGaps(
+  buckets: OhlcvBucket[],
+  interval: CandleInterval,
+): OhlcvBucket[] {
+  if (buckets.length === 0) {
+    return buckets;
+  }
+
+  const step = INTERVAL_SECONDS[interval];
+  const sorted = [...buckets].sort((a, b) => a.timestamp - b.timestamp);
+  const filled: OhlcvBucket[] = [sorted[0]];
+
+  for (let i = 1; i < sorted.length; i++) {
+    let expected = filled[filled.length - 1].timestamp + step;
+    const current = sorted[i];
+
+    while (expected < current.timestamp) {
+      const lastClose = filled[filled.length - 1].close;
+      filled.push({
+        timestamp: expected,
+        open: lastClose,
+        high: lastClose,
+        low: lastClose,
+        close: lastClose,
+        volume: '0',
+      });
+      expected += step;
+    }
+
+    filled.push(current);
+  }
+
+  return filled;
+}

--- a/apps/api/src/pools/inactive-pool.filter.ts
+++ b/apps/api/src/pools/inactive-pool.filter.ts
@@ -1,0 +1,28 @@
+export interface PoolActivityFields {
+  isActive?: boolean | null;
+  archivedAt?: Date | string | null;
+  tvl: string | number;
+}
+
+/**
+ * Default pool list policy: a pool is considered inactive/archived (and
+ * hidden from the default list) if it has been explicitly marked inactive,
+ * has an archivedAt timestamp set, or holds zero TVL. Callers that want to
+ * include archived pools (e.g. an "include archived" filter toggle) should
+ * bypass this helper and query unfiltered instead.
+ */
+export function isPoolActive(pool: PoolActivityFields): boolean {
+  if (pool.isActive === false) {
+    return false;
+  }
+  if (pool.archivedAt) {
+    return false;
+  }
+  return Number(pool.tvl) > 0;
+}
+
+export function filterActivePools<T extends PoolActivityFields>(
+  pools: T[],
+): T[] {
+  return pools.filter(isPoolActive);
+}

--- a/apps/api/src/search/pool-ranking.util.ts
+++ b/apps/api/src/search/pool-ranking.util.ts
@@ -1,0 +1,19 @@
+import { SearchPoolResult } from './search.service';
+
+export interface RankablePool extends SearchPoolResult {
+  volume24h: string | number;
+}
+
+/**
+ * Ranks pools by descending 24h volume. Ties are broken by poolId ascending
+ * so repeated queries against unchanged data always return the same order.
+ */
+export function rankPoolsByVolume<T extends RankablePool>(pools: T[]): T[] {
+  return [...pools].sort((a, b) => {
+    const volumeDiff = Number(b.volume24h) - Number(a.volume24h);
+    if (volumeDiff !== 0) {
+      return volumeDiff;
+    }
+    return a.poolId.localeCompare(b.poolId);
+  });
+}

--- a/prisma/migrations/20260726000000_pool_created_timestamp_index/migration.sql
+++ b/prisma/migrations/20260726000000_pool_created_timestamp_index/migration.sql
@@ -1,0 +1,3 @@
+-- Index the pool creation event timestamp so pool lists can be sorted and
+-- filtered by creation time without a full table scan.
+CREATE INDEX IF NOT EXISTS "pool_created_createdAt_idx" ON "pool_created" ("createdAt");


### PR DESCRIPTION
closes #504
closes #505 
closes #506 
closes #507


Search/pool ranking should prefer higher volume with stable ties.
Define and implement how missing candle buckets are represented.

Pool creation timestamp must be stored and indexed for sorting/filters.