### PR TITLE
fix: harden indexer recovery, rate-limit 429s, and search ranking

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -58,11 +58,24 @@ The `-v` flag removes the named `postgres_data` volume, giving you a clean datab
 ## Indexer recovery
 
 Each successfully persisted indexer event with a valid `ledger` field advances
-the monotonic `indexer:last_ledger` high-water mark in Redis and Postgres. The
+the monotonic `indexer:last_ledger` high-water mark in Redis and Postgres.
+Horizon only advances its in-memory paging token after a ledger window is
+successfully enqueued — it does **not** advance the durable checkpoint. The
 Postgres `indexer_cursor` row remains the durable recovery source when Redis is
 cold or unavailable. BullMQ retries stalled jobs, Prisma upserts keyed by
 `eventId` make the replay safe after a worker restart, and jobs that exhaust
 their retries are recorded in `indexer_dead_letter` for operator recovery.
+
+### Replay APIs (internal — `x-internal-key`)
+
+| Endpoint | Body | Behaviour |
+|---|---|---|
+| `POST /indexer/replay` | `{ "fromLedger": N }` | Re-enqueue canonical rows with `ledger >= N` |
+| `POST /indexer/dead-letters/replay` | `{ "jobId": "…" }` (optional) | Re-enqueue one DLQ job, or all unrecovered when omitted |
+
+Dead-letter replay is idempotent: workers upsert on `eventId` (and pool /
+position natural keys), and replayed BullMQ jobs use a stable
+`dlq-replay:<jobId>` id so a second call is a no-op or upsert-safe.
 
 ## Running tests
 

--- a/apps/api/src/horizon/horizon.service.spec.ts
+++ b/apps/api/src/horizon/horizon.service.spec.ts
@@ -6,6 +6,12 @@
  * request is ever made. BullMQ queues are stubbed to avoid Redis dependency.
  */
 
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({})),
+  Prisma: {},
+}));
+
+import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../cache/cache.service';
 import { IndexerCursorService } from '../indexer/indexer-cursor.service';
 import { PoolsService } from '../pools/pools.service';
@@ -36,6 +42,12 @@ function buildEffectsChain(records: object[]) {
 }
 
 function buildService(horizonServer: object) {
+  const config = {
+    get: jest.fn().mockReturnValue({
+      horizonUrl: 'https://horizon.test',
+      poolContractId: 'GPOOL_CONTRACT',
+    }),
+  } as unknown as ConfigService;
   const priceService = { broadcastPrice: jest.fn() } as unknown as PriceService;
   const poolsService = {
     handlePoolStateUpdate: jest.fn().mockResolvedValue(undefined),
@@ -54,14 +66,15 @@ function buildService(horizonServer: object) {
   const positionBurnedQueue = buildQueueMock();
 
   const service = new HorizonService(
+    config,
     priceService,
     poolsService,
     cache,
     cursorService,
-    poolCreatedQueue as any,
-    swapProcessedQueue as any,
-    positionMintedQueue as any,
-    positionBurnedQueue as any,
+    poolCreatedQueue as never,
+    swapProcessedQueue as never,
+    positionMintedQueue as never,
+    positionBurnedQueue as never,
   );
 
   // Inject stubbed Horizon server (bypasses real network)
@@ -88,7 +101,7 @@ describe('HorizonService — poller (Horizon mocked)', () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe('ledger checkpoint', () => {
-    it('advances the checkpoint after successfully processing an effect', async () => {
+    it('does not advance the durable ledger checkpoint after enqueue (worker owns writes)', async () => {
       const { server } = buildEffectsChain([
         {
           paging_token: 'cursor-1',
@@ -102,10 +115,59 @@ describe('HorizonService — poller (Horizon mocked)', () => {
       await (service as any).poll();
 
       expect(poolsService.handlePoolStateUpdate).toHaveBeenCalled();
-      expect(cursorService.advanceLedger).toHaveBeenCalledWith(900);
+      expect(cursorService.advanceLedger).not.toHaveBeenCalled();
     });
 
-    it('does not write a checkpoint when the ledger is invalid (negative)', async () => {
+    it('leaves the paging cursor unchanged when a ledger-window enqueue fails', async () => {
+      const { server } = buildEffectsChain([
+        {
+          paging_token: 'cursor-fail-a',
+          ledger: 910,
+          created_at: '2026-06-24T12:00:00.000Z',
+          eventType: 'swap_processed',
+          eventId: 'evt-ok',
+          poolId: 'pool-abc',
+          sender: 'GSENDER',
+          recipient: 'GRECIPIENT',
+          amount0: '1',
+          amount1: '1',
+          sqrtPrice: '1',
+          liquidity: '1',
+          tick: 0,
+        },
+        {
+          paging_token: 'cursor-fail-b',
+          ledger: 911,
+          created_at: '2026-06-24T12:00:01.000Z',
+          eventType: 'swap_processed',
+          eventId: 'evt-fail',
+          poolId: 'pool-abc',
+          sender: 'GSENDER',
+          recipient: 'GRECIPIENT',
+          amount0: '1',
+          amount1: '1',
+          sqrtPrice: '1',
+          liquidity: '1',
+          tick: 0,
+        },
+      ]);
+      const { service, swapProcessedQueue, cursorService } =
+        buildService(server);
+      (service as any).cursor = 'before';
+
+      swapProcessedQueue.addBulk
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(new Error('redis write failed mid-batch'));
+
+      await (service as any).poll();
+
+      // First ledger window enqueued successfully → paging advances to that window.
+      // Second window failed → durable checkpoint untouched; no skip past failure.
+      expect((service as any).cursor).toBe('cursor-fail-a');
+      expect(cursorService.advanceLedger).not.toHaveBeenCalled();
+    });
+
+    it('does not write a durable checkpoint when the ledger is invalid (negative)', async () => {
       const { server } = buildEffectsChain([
         {
           paging_token: 'cursor-2',
@@ -141,14 +203,17 @@ describe('HorizonService — poller (Horizon mocked)', () => {
 
       await (service as any).poll();
 
-      expect(poolCreatedQueue.add).toHaveBeenCalledWith(
-        'evt-pool-1',
-        expect.objectContaining({
-          poolId: 'pool-abc',
-          tokenA: 'TOKENA',
-          tokenB: 'TOKENB',
-        }),
-        expect.any(Object),
+      expect(poolCreatedQueue.addBulk).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'evt-pool-1',
+            data: expect.objectContaining({
+              poolId: 'pool-abc',
+              tokenA: 'TOKENA',
+              tokenB: 'TOKENB',
+            }),
+          }),
+        ]),
       );
     });
 
@@ -178,7 +243,10 @@ describe('HorizonService — poller (Horizon mocked)', () => {
         expect.arrayContaining([
           expect.objectContaining({
             name: 'evt-swap-1',
-            data: expect.objectContaining({ sender: 'GSENDER', recipient: 'GRECIPIENT' }),
+            data: expect.objectContaining({
+              sender: 'GSENDER',
+              recipient: 'GRECIPIENT',
+            }),
           }),
         ]),
       );
@@ -255,7 +323,10 @@ describe('HorizonService — poller (Horizon mocked)', () => {
         expect.arrayContaining([
           expect.objectContaining({
             name: 'evt-pos-1',
-            data: expect.objectContaining({ owner: 'GOWNER', tokenId: 'nft-1' }),
+            data: expect.objectContaining({
+              owner: 'GOWNER',
+              tokenId: 'nft-1',
+            }),
           }),
         ]),
       );
@@ -292,7 +363,9 @@ describe('HorizonService — poller (Horizon mocked)', () => {
             cursor: () => ({
               order: () => ({
                 limit: () => ({
-                  call: jest.fn().mockRejectedValue(new Error('network timeout')),
+                  call: jest
+                    .fn()
+                    .mockRejectedValue(new Error('network timeout')),
                 }),
               }),
             }),

--- a/apps/api/src/horizon/horizon.service.ts
+++ b/apps/api/src/horizon/horizon.service.ts
@@ -108,14 +108,17 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
           }
         }
 
+        // Enqueue the whole ledger window first. Only then advance the Horizon
+        // paging token for that window. If addBulk fails mid-page, earlier
+        // windows keep their paging progress and later ledgers are retried on
+        // the next poll — we never skip a failed batch.
+        //
+        // The durable indexer ledger checkpoint is advanced by IndexerWorker
+        // only after a successful Postgres write, not here after enqueue.
         await this.batchEnqueueLedgerWindow(records);
-      }
-
-      // Advance cursor and ledger checkpoint after processing all records.
-      for (const record of page.records) {
-        const typedRecord = record as unknown as IndexerEffectRecord;
-        await this.advanceLedger(typedRecord.ledger);
-        this.cursor = record.paging_token;
+        for (const record of records) {
+          this.cursor = record.paging_token;
+        }
       }
     } catch (err) {
       this.logger.warn(`Horizon poll error: ${(err as Error).message}`);
@@ -131,7 +134,14 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
   private async batchEnqueueLedgerWindow(
     records: IndexerEffectRecord[],
   ): Promise<void> {
-    type JobEntry = { name: string; data: PoolCreatedJobData | SwapProcessedJobData | PositionMintedJobData | PositionBurnedJobData };
+    type JobEntry = {
+      name: string;
+      data:
+        | PoolCreatedJobData
+        | SwapProcessedJobData
+        | PositionMintedJobData
+        | PositionBurnedJobData;
+    };
 
     const poolCreatedJobs: JobEntry[] = [];
     const swapProcessedJobs: JobEntry[] = [];
@@ -215,16 +225,24 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
     const opts = { removeOnComplete: true };
     await Promise.all([
       poolCreatedJobs.length
-        ? this.poolCreatedQueue.addBulk(poolCreatedJobs.map((j) => ({ ...j, opts })))
+        ? this.poolCreatedQueue.addBulk(
+            poolCreatedJobs.map((j) => ({ ...j, opts })),
+          )
         : Promise.resolve(),
       swapProcessedJobs.length
-        ? this.swapProcessedQueue.addBulk(swapProcessedJobs.map((j) => ({ ...j, opts })))
+        ? this.swapProcessedQueue.addBulk(
+            swapProcessedJobs.map((j) => ({ ...j, opts })),
+          )
         : Promise.resolve(),
       positionMintedJobs.length
-        ? this.positionMintedQueue.addBulk(positionMintedJobs.map((j) => ({ ...j, opts })))
+        ? this.positionMintedQueue.addBulk(
+            positionMintedJobs.map((j) => ({ ...j, opts })),
+          )
         : Promise.resolve(),
       positionBurnedJobs.length
-        ? this.positionBurnedQueue.addBulk(positionBurnedJobs.map((j) => ({ ...j, opts })))
+        ? this.positionBurnedQueue.addBulk(
+            positionBurnedJobs.map((j) => ({ ...j, opts })),
+          )
         : Promise.resolve(),
     ]);
   }
@@ -241,13 +259,6 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
       liquidity: r.liquidity ?? '0',
       timestamp: new Date(r.created_at).getTime(),
     };
-  }
-
-  private async advanceLedger(ledger?: number): Promise<void> {
-    if (!Number.isSafeInteger(ledger) || ledger === undefined || ledger < 0) {
-      return;
-    }
-    await this.cursorService.advanceLedger(ledger);
   }
 }
 

--- a/apps/api/src/indexer/dto/replay-dead-letter.dto.ts
+++ b/apps/api/src/indexer/dto/replay-dead-letter.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ReplayDeadLetterDto {
+  @ApiPropertyOptional({
+    description:
+      'Replay a single dead-letter job by its BullMQ jobId. Omit to replay all unrecovered entries.',
+    example: 'job-123',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  jobId?: string;
+}

--- a/apps/api/src/indexer/indexer-dead-letter.service.ts
+++ b/apps/api/src/indexer/indexer-dead-letter.service.ts
@@ -47,41 +47,72 @@ export class IndexerDeadLetterService {
   }
 
   /**
-   * Get all dead letter entries for inspection
+   * Get all dead letter entries for inspection.
+   * When `unrecoveredOnly` is true, skips entries that already have `recoveredAt`.
    */
   async getDeadLetters(
     queueName?: string,
     limit: number = 100,
+    unrecoveredOnly = false,
   ): Promise<DeadLetterEntry[]> {
     try {
       const entries = await this.prisma.indexerDeadLetter.findMany({
-        where: queueName ? { queueName } : undefined,
+        where: {
+          ...(queueName ? { queueName } : {}),
+          ...(unrecoveredOnly ? { recoveredAt: null } : {}),
+        },
         orderBy: { createdAt: 'desc' },
         take: limit,
       });
 
-      return entries.map((entry) => {
-        let data: Record<string, unknown> = {};
-        try {
-          data = JSON.parse(entry.data) as Record<string, unknown>;
-        } catch {
-          this.logger.warn(`Invalid DLQ payload for job ${entry.jobId}`);
-        }
-        return {
-          jobId: entry.jobId,
-          queueName: entry.queueName,
-          eventId: entry.eventId,
-          data,
-          error: entry.error,
-          attemptsMade: entry.attemptsMade,
-        };
-      });
+      return entries.map((entry) => this.toEntry(entry));
     } catch (err) {
       this.logger.error(
         `Failed to retrieve dead letters: ${(err as Error).message}`,
       );
       return [];
     }
+  }
+
+  /**
+   * Look up a single dead-letter row by BullMQ job id (recovered or not).
+   */
+  async getDeadLetter(jobId: string): Promise<DeadLetterEntry | null> {
+    try {
+      const entry = await this.prisma.indexerDeadLetter.findUnique({
+        where: { jobId },
+      });
+      return entry ? this.toEntry(entry) : null;
+    } catch (err) {
+      this.logger.error(
+        `Failed to retrieve dead letter ${jobId}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  private toEntry(entry: {
+    jobId: string;
+    queueName: string;
+    eventId: string;
+    data: string;
+    error: string;
+    attemptsMade: number;
+  }): DeadLetterEntry {
+    let data: Record<string, unknown> = {};
+    try {
+      data = JSON.parse(entry.data) as Record<string, unknown>;
+    } catch {
+      this.logger.warn(`Invalid DLQ payload for job ${entry.jobId}`);
+    }
+    return {
+      jobId: entry.jobId,
+      queueName: entry.queueName,
+      eventId: entry.eventId,
+      data,
+      error: entry.error,
+      attemptsMade: entry.attemptsMade,
+    };
   }
 
   /**

--- a/apps/api/src/indexer/indexer-replay.service.spec.ts
+++ b/apps/api/src/indexer/indexer-replay.service.spec.ts
@@ -1,0 +1,132 @@
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    poolCreated: { findMany: jest.fn().mockResolvedValue([]) },
+    swapProcessed: { findMany: jest.fn().mockResolvedValue([]) },
+    positionMinted: { findMany: jest.fn().mockResolvedValue([]) },
+    positionBurned: { findMany: jest.fn().mockResolvedValue([]) },
+    feesCollected: { findMany: jest.fn().mockResolvedValue([]) },
+    $disconnect: jest.fn(),
+  })),
+}));
+
+import { QUEUE_NAMES } from './queues';
+import { IndexerReplayService } from './indexer-replay.service';
+
+describe('IndexerReplayService — dead-letter replay', () => {
+  const poolCreatedQueue = { add: jest.fn().mockResolvedValue({ id: '1' }) };
+  const swapProcessedQueue = { add: jest.fn().mockResolvedValue({ id: '2' }) };
+  const positionMintedQueue = { add: jest.fn().mockResolvedValue({ id: '3' }) };
+  const positionBurnedQueue = { add: jest.fn().mockResolvedValue({ id: '4' }) };
+  const feesCollectedQueue = { add: jest.fn().mockResolvedValue({ id: '5' }) };
+
+  const deadLetterService = {
+    getDeadLetters: jest.fn(),
+    getDeadLetter: jest.fn(),
+    clearDeadLetter: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const buildService = () =>
+    new IndexerReplayService(
+      poolCreatedQueue as never,
+      swapProcessedQueue as never,
+      positionMintedQueue as never,
+      positionBurnedQueue as never,
+      feesCollectedQueue as never,
+      deadLetterService as never,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('re-enqueues a DLQ swap and marks it recovered', async () => {
+    deadLetterService.getDeadLetter.mockResolvedValue({
+      jobId: 'job-swap-1',
+      queueName: QUEUE_NAMES.SWAP_PROCESSED,
+      eventId: 'evt-swap-1',
+      data: {
+        eventId: 'evt-swap-1',
+        poolId: 'pool-1',
+        sender: 'S',
+        recipient: 'R',
+        amount0: '1',
+        amount1: '2',
+        sqrtPriceX96: '1',
+        liquidity: '1',
+        tick: 0,
+      },
+      error: 'boom',
+      attemptsMade: 3,
+    });
+
+    const summary = await buildService().replayDeadLetters('job-swap-1');
+
+    expect(swapProcessedQueue.add).toHaveBeenCalledWith(
+      'evt-swap-1',
+      expect.objectContaining({ eventId: 'evt-swap-1' }),
+      expect.objectContaining({ jobId: 'dlq-replay:job-swap-1' }),
+    );
+    expect(deadLetterService.clearDeadLetter).toHaveBeenCalledWith(
+      'job-swap-1',
+    );
+    expect(summary).toEqual({
+      replayed: ['job-swap-1'],
+      skipped: [],
+      total: 1,
+    });
+  });
+
+  it('treats a second replay of the same DLQ jobId as an idempotent no-op', async () => {
+    deadLetterService.getDeadLetter.mockResolvedValue({
+      jobId: 'job-swap-1',
+      queueName: QUEUE_NAMES.SWAP_PROCESSED,
+      eventId: 'evt-swap-1',
+      data: { eventId: 'evt-swap-1', poolId: 'pool-1' },
+      error: 'boom',
+      attemptsMade: 3,
+    });
+
+    swapProcessedQueue.add
+      .mockResolvedValueOnce({ id: '2' })
+      .mockRejectedValueOnce(new Error('Job with this id already exists'));
+
+    const service = buildService();
+    await service.replayDeadLetters('job-swap-1');
+    const second = await service.replayDeadLetters('job-swap-1');
+
+    expect(swapProcessedQueue.add).toHaveBeenCalledTimes(2);
+    expect(second.replayed).toEqual(['job-swap-1']);
+    expect(second.skipped).toEqual([]);
+    expect(deadLetterService.clearDeadLetter).toHaveBeenCalledTimes(2);
+  });
+
+  it('replays all unrecovered DLQ entries when jobId is omitted', async () => {
+    deadLetterService.getDeadLetters.mockResolvedValue([
+      {
+        jobId: 'job-pool-1',
+        queueName: QUEUE_NAMES.POOL_CREATED,
+        eventId: 'evt-pool-1',
+        data: {
+          eventId: 'evt-pool-1',
+          poolId: 'p',
+          tokenA: 'A',
+          tokenB: 'B',
+          fee: '1',
+          sqrtPriceX96: '1',
+        },
+        error: 'boom',
+        attemptsMade: 3,
+      },
+    ]);
+
+    const summary = await buildService().replayDeadLetters();
+
+    expect(deadLetterService.getDeadLetters).toHaveBeenCalledWith(
+      undefined,
+      500,
+      true,
+    );
+    expect(poolCreatedQueue.add).toHaveBeenCalled();
+    expect(summary.total).toBe(1);
+  });
+});

--- a/apps/api/src/indexer/indexer-replay.service.ts
+++ b/apps/api/src/indexer/indexer-replay.service.ts
@@ -1,7 +1,14 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { Queue } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
 import {
+  QUEUE_NAMES,
   QUEUE_POOL_CREATED,
   QUEUE_SWAP_PROCESSED,
   QUEUE_POSITION_MINTED,
@@ -12,7 +19,12 @@ import {
   PositionMintedJobData,
   PositionBurnedJobData,
   FeesCollectedJobData,
+  QueueName,
 } from './queues';
+import {
+  DeadLetterEntry,
+  IndexerDeadLetterService,
+} from './indexer-dead-letter.service';
 
 export interface ReplaySummary {
   fromLedger: number;
@@ -23,6 +35,14 @@ export interface ReplaySummary {
     positionBurned: number;
     feesCollected: number;
   };
+  total: number;
+}
+
+export interface DeadLetterReplaySummary {
+  /** Job ids that were re-enqueued. */
+  replayed: string[];
+  /** Job ids skipped because the payload/queue was invalid. */
+  skipped: string[];
   total: number;
 }
 
@@ -50,7 +70,129 @@ export class IndexerReplayService {
     private readonly positionBurnedQueue: Queue<PositionBurnedJobData>,
     @Inject(QUEUE_FEES_COLLECTED)
     private readonly feesCollectedQueue: Queue<FeesCollectedJobData>,
+    private readonly deadLetterService: IndexerDeadLetterService,
   ) {}
+
+  /**
+   * Re-enqueues dead-lettered jobs onto their original BullMQ queues.
+   *
+   * Handlers upsert on `eventId` (and pool/position natural keys), so replaying
+   * the same DLQ item twice is idempotent: pool balances / TVL / swap rows are
+   * not double-applied. Pass `jobId` to replay one entry (even if previously
+   * marked recovered); omit it to replay all unrecovered entries.
+   */
+  async replayDeadLetters(jobId?: string): Promise<DeadLetterReplaySummary> {
+    const entries = jobId
+      ? await this.loadSingleDeadLetter(jobId)
+      : await this.deadLetterService.getDeadLetters(undefined, 500, true);
+
+    const replayed: string[] = [];
+    const skipped: string[] = [];
+
+    for (const entry of entries) {
+      const ok = await this.enqueueDeadLetter(entry);
+      if (!ok) {
+        skipped.push(entry.jobId);
+        continue;
+      }
+      await this.deadLetterService.clearDeadLetter(entry.jobId);
+      replayed.push(entry.jobId);
+    }
+
+    this.logger.log(
+      `DLQ replay enqueued=${replayed.length} skipped=${skipped.length}` +
+        (jobId ? ` jobId=${jobId}` : ''),
+    );
+
+    return { replayed, skipped, total: replayed.length };
+  }
+
+  private async loadSingleDeadLetter(
+    jobId: string,
+  ): Promise<DeadLetterEntry[]> {
+    const entry = await this.deadLetterService.getDeadLetter(jobId);
+    if (!entry) {
+      throw new NotFoundException(`Dead letter job not found: ${jobId}`);
+    }
+    return [entry];
+  }
+
+  private async enqueueDeadLetter(entry: DeadLetterEntry): Promise<boolean> {
+    const queueName = entry.queueName as QueueName;
+    const eventId =
+      typeof entry.data.eventId === 'string' && entry.data.eventId
+        ? entry.data.eventId
+        : entry.eventId;
+    if (!eventId) {
+      this.logger.warn(
+        `Skipping DLQ job ${entry.jobId} — missing eventId in payload`,
+      );
+      return false;
+    }
+
+    const opts = {
+      ...IndexerReplayService.ENQUEUE_OPTS,
+      // Stable job id so a second replay of the same DLQ item is a no-op in
+      // BullMQ when the prior job is still present; workers remain upsert-safe
+      // even if the job is re-added under a new id.
+      jobId: `dlq-replay:${entry.jobId}`,
+    };
+
+    try {
+      switch (queueName) {
+        case QUEUE_NAMES.POOL_CREATED:
+          await this.poolCreatedQueue.add(
+            eventId,
+            entry.data as unknown as PoolCreatedJobData,
+            opts,
+          );
+          return true;
+        case QUEUE_NAMES.SWAP_PROCESSED:
+          await this.swapProcessedQueue.add(
+            eventId,
+            entry.data as unknown as SwapProcessedJobData,
+            opts,
+          );
+          return true;
+        case QUEUE_NAMES.POSITION_MINTED:
+          await this.positionMintedQueue.add(
+            eventId,
+            entry.data as unknown as PositionMintedJobData,
+            opts,
+          );
+          return true;
+        case QUEUE_NAMES.POSITION_BURNED:
+          await this.positionBurnedQueue.add(
+            eventId,
+            entry.data as unknown as PositionBurnedJobData,
+            opts,
+          );
+          return true;
+        case QUEUE_NAMES.FEES_COLLECTED:
+          await this.feesCollectedQueue.add(
+            eventId,
+            entry.data as unknown as FeesCollectedJobData,
+            opts,
+          );
+          return true;
+        default:
+          throw new BadRequestException(
+            `Unsupported DLQ queueName: ${entry.queueName}`,
+          );
+      }
+    } catch (err) {
+      // BullMQ rejects duplicate jobId — treat as idempotent no-op success.
+      const message = err instanceof Error ? err.message : String(err);
+      if (/already exists|Job with this? id/i.test(message)) {
+        this.logger.debug(
+          `DLQ replay job ${entry.jobId} already queued — treating as no-op`,
+        );
+        return true;
+      }
+      this.logger.error(`Failed to enqueue DLQ job ${entry.jobId}: ${message}`);
+      return false;
+    }
+  }
 
   async replayFromLedger(fromLedger: number): Promise<ReplaySummary> {
     const [

--- a/apps/api/src/indexer/indexer-state.spec.ts
+++ b/apps/api/src/indexer/indexer-state.spec.ts
@@ -6,6 +6,7 @@ const mockPrismaClient = {
   indexerDeadLetter: {
     upsert: jest.fn().mockResolvedValue({}),
     findMany: jest.fn(),
+    findUnique: jest.fn(),
     update: jest.fn().mockResolvedValue({}),
     count: jest.fn().mockResolvedValue(0),
   },
@@ -39,7 +40,10 @@ describe('IndexerCursorService', () => {
     await expect(new IndexerCursorService(cache).getLastLedger()).resolves.toBe(
       42,
     );
-    expect(cache.setMaxNumber).toHaveBeenCalledWith(LAST_INDEXED_LEDGER_KEY, 42);
+    expect(cache.setMaxNumber).toHaveBeenCalledWith(
+      LAST_INDEXED_LEDGER_KEY,
+      42,
+    );
   });
 
   it('rejects stale or invalid cursor writes', async () => {

--- a/apps/api/src/indexer/indexer.controller.ts
+++ b/apps/api/src/indexer/indexer.controller.ts
@@ -1,8 +1,13 @@
 import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { IndexerWorker } from './indexer.worker';
-import { IndexerReplayService, ReplaySummary } from './indexer-replay.service';
+import {
+  DeadLetterReplaySummary,
+  IndexerReplayService,
+  ReplaySummary,
+} from './indexer-replay.service';
 import { ReplayDto } from './dto/replay.dto';
+import { ReplayDeadLetterDto } from './dto/replay-dead-letter.dto';
 import { InternalKeyGuard } from '../admin/internal-key.guard';
 import { SWAGGER_TAGS } from '../swagger.constants';
 
@@ -79,8 +84,36 @@ export class IndexerController {
   @UseGuards(InternalKeyGuard)
   @ApiOperation({
     summary: 'Replay persisted events from a given ledger onward (internal)',
+    description:
+      'Re-enqueues canonical event rows. Worker handlers upsert on eventId, so replay is safe if events already landed.',
   })
   replay(@Body() body: ReplayDto): Promise<ReplaySummary> {
     return this.replayService.replayFromLedger(body.fromLedger);
+  }
+
+  /**
+   * Re-enqueues poison jobs from `indexer_dead_letter`.
+   *
+   * **Usage**
+   * - `POST /indexer/dead-letters/replay` with `{ "jobId": "<bull-job-id>" }`
+   *   re-enqueues that single DLQ payload (works even if previously recovered).
+   * - `POST /indexer/dead-letters/replay` with `{}` re-enqueues all unrecovered
+   *   DLQ rows (cap 500).
+   *
+   * Replays are idempotent: handlers upsert on `eventId` / pool id / position
+   * keys, and BullMQ job ids are stable (`dlq-replay:<jobId>`), so a second
+   * replay is a no-op or upsert-safe and must not double-apply balances/TVL.
+   */
+  @Post('dead-letters/replay')
+  @UseGuards(InternalKeyGuard)
+  @ApiOperation({
+    summary: 'Replay dead-letter indexer jobs (internal, idempotent)',
+    description:
+      'Re-enqueues DLQ payloads. Safe to call twice — upsert keys and stable BullMQ job ids prevent double-application of pool/swap projections.',
+  })
+  replayDeadLetters(
+    @Body() body: ReplayDeadLetterDto,
+  ): Promise<DeadLetterReplaySummary> {
+    return this.replayService.replayDeadLetters(body.jobId);
   }
 }

--- a/apps/api/src/indexer/indexer.spec.ts
+++ b/apps/api/src/indexer/indexer.spec.ts
@@ -355,14 +355,13 @@ describe('IndexerWorker', () => {
       const failed = mockWorkerOn.mock.calls.find(
         (c) => c[0] === 'failed',
       )?.[1] as
-        | ((job: Job<PoolCreatedJobData>, err: Error) => void)
-        | undefined;
+        ((job: Job<PoolCreatedJobData>, err: Error) => void) | undefined;
 
       failed?.(
         makeJob({
           eventId: 'evt-poison',
           poolId: 'pool',
-        } as PoolCreatedJobData) as Job<PoolCreatedJobData>,
+        } as PoolCreatedJobData),
         new Error('poison event'),
       );
 
@@ -533,6 +532,7 @@ describe('IndexerWorker', () => {
         12345,
       );
       expect(mockAdvanceLedger).toHaveBeenCalledWith(12345);
+      expect(mockSetMaxNumber).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches a pool.created webhook after successful write', async () => {
@@ -568,8 +568,12 @@ describe('IndexerWorker', () => {
       const handler = getHandlerForQueue(QUEUE_NAMES.POOL_CREATED);
       await handler(makeJob(data));
 
-      expect(mockTokenEnrichmentService.enrichToken).toHaveBeenCalledWith(data.tokenA);
-      expect(mockTokenEnrichmentService.enrichToken).toHaveBeenCalledWith(data.tokenB);
+      expect(mockTokenEnrichmentService.enrichToken).toHaveBeenCalledWith(
+        data.tokenA,
+      );
+      expect(mockTokenEnrichmentService.enrichToken).toHaveBeenCalledWith(
+        data.tokenB,
+      );
     });
 
     it('persists pool createdAt from event timestamp', async () => {
@@ -603,7 +607,9 @@ describe('IndexerWorker', () => {
       // Verify the date is between before and after (within 1s tolerance)
       const callArgs = (mockPrismaClient.pool.upsert as any).mock.calls[0][0];
       const createdAt = callArgs.create.createdAt;
-      expect(createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+      expect(createdAt.getTime()).toBeGreaterThanOrEqual(
+        before.getTime() - 1000,
+      );
       expect(createdAt.getTime()).toBeLessThanOrEqual(after.getTime() + 1000);
     });
   });

--- a/apps/api/src/indexer/indexer.worker.integration.spec.ts
+++ b/apps/api/src/indexer/indexer.worker.integration.spec.ts
@@ -106,57 +106,94 @@ function makeUpsert<T extends Record<string, unknown>>(
   store: Map<string, T>,
   keyFn: (where: Record<string, unknown>) => string,
 ) {
-  return jest.fn().mockImplementation(async ({ where, create, update }: {
-    where: Record<string, unknown>;
-    create: T;
-    update: Partial<T>;
-  }) => {
-    const key = keyFn(where);
-    if (store.has(key)) {
-      const existing = store.get(key)!;
-      const merged = { ...existing, ...update } as T;
-      store.set(key, merged);
-      return merged;
-    }
-    store.set(key, create);
-    return create;
-  });
+  return jest
+    .fn()
+    .mockImplementation(
+      async ({
+        where,
+        create,
+        update,
+      }: {
+        where: Record<string, unknown>;
+        create: T;
+        update: Partial<T>;
+      }) => {
+        const key = keyFn(where);
+        if (store.has(key)) {
+          const existing = store.get(key)!;
+          const merged = { ...existing, ...update };
+          store.set(key, merged);
+          return merged;
+        }
+        store.set(key, create);
+        return create;
+      },
+    );
 }
 
 const mockPrismaClient = {
   token: {
-    upsert: makeUpsert(db.tokens as Map<string, Record<string, unknown>>, (w) => w.address as string),
+    upsert: makeUpsert(
+      db.tokens as Map<string, Record<string, unknown>>,
+      (w) => w.address as string,
+    ),
   },
   pool: {
-    upsert: makeUpsert(db.pools as Map<string, Record<string, unknown>>, (w) => w.id as string),
-    findUnique: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
-      return db.pools.get(where.id) ?? null;
-    }),
+    upsert: makeUpsert(
+      db.pools as Map<string, Record<string, unknown>>,
+      (w) => w.id as string,
+    ),
+    findUnique: jest
+      .fn()
+      .mockImplementation(async ({ where }: { where: { id: string } }) => {
+        return db.pools.get(where.id) ?? null;
+      }),
   },
   swap: {
-    upsert: makeUpsert(db.swaps as Map<string, Record<string, unknown>>, (w) => w.eventId as string),
+    upsert: makeUpsert(
+      db.swaps as Map<string, Record<string, unknown>>,
+      (w) => w.eventId as string,
+    ),
   },
   position: {
-    upsert: makeUpsert(db.positions as Map<string, Record<string, unknown>>, (w) => {
-      const pk = w.poolId_tokenId as { poolId: string; tokenId: string };
-      return `${pk.poolId}:${pk.tokenId}`;
-    }),
+    upsert: makeUpsert(
+      db.positions as Map<string, Record<string, unknown>>,
+      (w) => {
+        const pk = w.poolId_tokenId as { poolId: string; tokenId: string };
+        return `${pk.poolId}:${pk.tokenId}`;
+      },
+    ),
     update: jest.fn().mockResolvedValue({}),
   },
   poolCreated: {
-    upsert: makeUpsert(db.poolCreated as Map<string, Record<string, unknown>>, (w) => w.eventId as string),
+    upsert: makeUpsert(
+      db.poolCreated as Map<string, Record<string, unknown>>,
+      (w) => w.eventId as string,
+    ),
   },
   swapProcessed: {
-    upsert: makeUpsert(db.swapProcessed as Map<string, Record<string, unknown>>, (w) => w.eventId as string),
+    upsert: makeUpsert(
+      db.swapProcessed as Map<string, Record<string, unknown>>,
+      (w) => w.eventId as string,
+    ),
   },
   positionMinted: {
-    upsert: makeUpsert(db.positionMinted as Map<string, Record<string, unknown>>, (w) => w.eventId as string),
+    upsert: makeUpsert(
+      db.positionMinted as Map<string, Record<string, unknown>>,
+      (w) => w.eventId as string,
+    ),
   },
   positionBurned: {
-    upsert: makeUpsert(db.positionBurned as Map<string, Record<string, unknown>>, (w) => w.eventId as string),
+    upsert: makeUpsert(
+      db.positionBurned as Map<string, Record<string, unknown>>,
+      (w) => w.eventId as string,
+    ),
   },
   feesCollected: {
-    upsert: makeUpsert(db.feesCollected as Map<string, Record<string, unknown>>, (w) => w.eventId as string),
+    upsert: makeUpsert(
+      db.feesCollected as Map<string, Record<string, unknown>>,
+      (w) => w.eventId as string,
+    ),
   },
   $disconnect: jest.fn().mockResolvedValue(undefined),
 };
@@ -174,6 +211,8 @@ import { CacheService } from '../cache/cache.service';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { TokenEnrichmentService } from '../tokens/token-enrichment.service';
 import { LAST_INDEXED_LEDGER_KEY } from '../metrics/indexer-monitor.service';
+import { IndexerCursorService } from './indexer-cursor.service';
+import { IndexerDeadLetterService } from './indexer-dead-letter.service';
 import { QUEUE_NAMES } from './queues';
 import type {
   PoolCreatedJobData,
@@ -220,6 +259,19 @@ describe('IndexerWorker Integration (test-db)', () => {
         {
           provide: CacheService,
           useValue: { setMaxNumber: mockSetMaxNumber },
+        },
+        {
+          provide: IndexerCursorService,
+          useValue: {
+            advanceLedger: (ledger: number) =>
+              mockSetMaxNumber(LAST_INDEXED_LEDGER_KEY, ledger),
+          },
+        },
+        {
+          provide: IndexerDeadLetterService,
+          useValue: {
+            recordDeadLetter: jest.fn().mockResolvedValue(undefined),
+          },
         },
         {
           provide: WebhooksService,
@@ -281,7 +333,10 @@ describe('IndexerWorker Integration (test-db)', () => {
       const handler = getHandler(QUEUE_NAMES.POOL_CREATED);
       await handler(makeJob(poolData));
 
-      expect(mockSetMaxNumber).toHaveBeenCalledWith(LAST_INDEXED_LEDGER_KEY, 1000);
+      expect(mockSetMaxNumber).toHaveBeenCalledWith(
+        LAST_INDEXED_LEDGER_KEY,
+        1000,
+      );
     });
 
     it('is idempotent: duplicate event does not create duplicate rows', async () => {
@@ -359,12 +414,21 @@ describe('IndexerWorker Integration (test-db)', () => {
       const handler = getHandler(QUEUE_NAMES.SWAP_PROCESSED);
       await handler(makeJob(swapData));
 
-      expect(mockSetMaxNumber).toHaveBeenCalledWith(LAST_INDEXED_LEDGER_KEY, 1001);
+      expect(mockSetMaxNumber).toHaveBeenCalledWith(
+        LAST_INDEXED_LEDGER_KEY,
+        1001,
+      );
     });
 
     it('skips invalid sqrtPrice but still persists swap row', async () => {
       const handler = getHandler(QUEUE_NAMES.SWAP_PROCESSED);
-      await handler(makeJob({ ...swapData, sqrtPriceX96: '0', eventId: 'int-swap-invalid' }));
+      await handler(
+        makeJob({
+          ...swapData,
+          sqrtPriceX96: '0',
+          eventId: 'int-swap-invalid',
+        }),
+      );
 
       expect(db.swaps.has('int-swap-invalid')).toBe(true);
     });
@@ -391,7 +455,10 @@ describe('IndexerWorker Integration (test-db)', () => {
       const handler = getHandler(QUEUE_NAMES.FEES_COLLECTED);
       await handler(makeJob(feesData));
 
-      expect(mockSetMaxNumber).toHaveBeenCalledWith(LAST_INDEXED_LEDGER_KEY, 1002);
+      expect(mockSetMaxNumber).toHaveBeenCalledWith(
+        LAST_INDEXED_LEDGER_KEY,
+        1002,
+      );
     });
   });
 
@@ -481,6 +548,27 @@ describe('IndexerWorker Integration (test-db)', () => {
       expect(mockSetMaxNumber).not.toHaveBeenCalled();
     });
 
+    it('advances the ledger checkpoint exactly once after a successful write', async () => {
+      const handler = getHandler(QUEUE_NAMES.POOL_CREATED);
+      await handler(
+        makeJob<PoolCreatedJobData>({
+          eventId: 'int-once-1',
+          poolId: 'pool-once',
+          tokenA: 'A',
+          tokenB: 'B',
+          fee: '30',
+          sqrtPriceX96: '1',
+          ledger: 4242,
+        }),
+      );
+
+      expect(mockSetMaxNumber).toHaveBeenCalledTimes(1);
+      expect(mockSetMaxNumber).toHaveBeenCalledWith(
+        LAST_INDEXED_LEDGER_KEY,
+        4242,
+      );
+    });
+
     it('skips write and warns on empty eventId', async () => {
       const handler = getHandler(QUEUE_NAMES.FEES_COLLECTED);
       await handler(
@@ -494,6 +582,52 @@ describe('IndexerWorker Integration (test-db)', () => {
       );
 
       expect(db.feesCollected.size).toBe(0);
+    });
+  });
+
+  describe('dead-letter replay idempotency', () => {
+    it('processing the same swap DLQ payload twice does not change TVL/volume', async () => {
+      db.pools.set('pool-dlq-1', {
+        id: 'pool-dlq-1',
+        token0Address: 'XLM',
+        token1Address: 'USDC',
+        feeTier: 3000,
+        currentSqrtPrice: '1',
+        currentTick: 0,
+        liquidity: '1000',
+        tvl: '50000',
+        volume24h: '12000',
+        feeApr: '0.1',
+      });
+
+      const swapData: SwapProcessedJobData = {
+        eventId: 'dlq-swap-1',
+        poolId: 'pool-dlq-1',
+        sender: '0xSender',
+        recipient: '0xRecipient',
+        amount0: '100',
+        amount1: '-50',
+        sqrtPriceX96: '79228162514264337593543950336',
+        liquidity: '2000',
+        tick: 7,
+        ledger: 5555,
+      };
+
+      const handler = getHandler(QUEUE_NAMES.SWAP_PROCESSED);
+      await handler(makeJob(swapData));
+      const afterFirst = { ...(db.pools.get('pool-dlq-1') as PoolRow) };
+
+      await handler(makeJob(swapData));
+      const afterSecond = db.pools.get('pool-dlq-1') as PoolRow;
+
+      expect(db.swaps.size).toBe(1);
+      expect(afterSecond.tvl).toBe(afterFirst.tvl);
+      expect(afterSecond.volume24h).toBe(afterFirst.volume24h);
+      expect(afterSecond.tvl).toBe('50000');
+      expect(afterSecond.volume24h).toBe('12000');
+      // Absolute pool state fields stay at the same projected values.
+      expect(afterSecond.currentTick).toBe(afterFirst.currentTick);
+      expect(afterSecond.liquidity).toBe(afterFirst.liquidity);
     });
   });
 });

--- a/apps/api/src/rate-limit/rate-limit.middleware.spec.ts
+++ b/apps/api/src/rate-limit/rate-limit.middleware.spec.ts
@@ -88,4 +88,40 @@ describe('RateLimitMiddleware', () => {
     expect(res.headers.get('X-RateLimit-Limit')).toBe('300');
     expect(next).toHaveBeenCalled();
   });
+
+  it('returns the standard ErrorResponse body on 429 with Retry-After', async () => {
+    const middleware = new RateLimitMiddleware();
+    (middleware as unknown as { redis: object }).redis = {
+      incr: jest.fn().mockResolvedValue(301),
+      expire: jest.fn(),
+      ttl: jest.fn().mockResolvedValue(42),
+    };
+    const res = response();
+
+    await middleware.use(
+      {
+        path: '/pools',
+        originalUrl: '/v1/pools',
+        method: 'GET',
+        headers: {},
+        ip: '203.0.113.10',
+      } as never,
+      res as never,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.headers.get('Retry-After')).toBe('42');
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 429,
+        message: 'Too many requests',
+        error: 'Too Many Requests',
+        path: '/v1/pools',
+        retryAfter: '42',
+        timestamp: expect.any(String),
+      }),
+    );
+  });
 });

--- a/apps/api/src/rate-limit/rate-limit.middleware.ts
+++ b/apps/api/src/rate-limit/rate-limit.middleware.ts
@@ -6,6 +6,8 @@ import {
 } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
 import Redis from 'ioredis';
+import { RequestContext } from '../logging/request-context';
+import { ErrorResponse } from '../request-validation/error-response.interface';
 
 /** A named rate-limit rule that defines a sliding-window counter. */
 interface RateLimitRule {
@@ -85,7 +87,9 @@ export class RateLimitMiddleware
    *
    * Evaluates all applicable rate-limit rules for the incoming request and
    * either calls `next()` (request allowed) or responds with HTTP 429
-   * (request blocked).
+   * (request blocked) using the shared {@link ErrorResponse} body shape
+   * (`statusCode`, `message`, `error`, `timestamp`, `path`, optional
+   * `requestId`) plus `retryAfter` and the `Retry-After` response header.
    *
    * Response headers set on every non-health request:
    * - `X-RateLimit-Limit` — the effective window limit
@@ -132,12 +136,18 @@ export class RateLimitMiddleware
     );
 
     if (effective.exceeded) {
-      res.setHeader('Retry-After', effective.resetSeconds.toString());
-      res.status(429).json({
+      const retryAfter = effective.resetSeconds.toString();
+      res.setHeader('Retry-After', retryAfter);
+      const body: ErrorResponse & { retryAfter?: string } = {
         statusCode: 429,
         message: 'Too many requests',
         error: 'Too Many Requests',
-      });
+        timestamp: new Date().toISOString(),
+        path: req.originalUrl || req.path,
+        requestId: RequestContext.requestId,
+        retryAfter,
+      };
+      res.status(429).json(body);
       return;
     }
 

--- a/apps/api/src/search/search.controller.ts
+++ b/apps/api/src/search/search.controller.ts
@@ -11,6 +11,8 @@ export class SearchController {
   @Get()
   @ApiOperation({
     summary: 'Search for tokens and pools by symbol, name, or address',
+    description:
+      'Pool results are ranked by 24h volume descending, then by pool id ascending so equal-volume ties stay stable across requests.',
   })
   @ApiQuery({
     name: 'q',
@@ -18,7 +20,11 @@ export class SearchController {
     description: 'Search query (min 2 characters)',
     example: 'USDC',
   })
-  @ApiResponse({ status: 200, description: 'Matching tokens and pools' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Matching tokens and pools. Pools ordered by volume24h DESC, then poolId ASC.',
+  })
   search(@Query('q') query = ''): Promise<SearchResponse> {
     return this.searchService.search(query);
   }

--- a/apps/api/src/search/search.service.spec.ts
+++ b/apps/api/src/search/search.service.spec.ts
@@ -1,3 +1,8 @@
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(),
+  Prisma: {},
+}));
+
 import { SearchService } from './search.service';
 
 describe('SearchService', () => {
@@ -81,5 +86,37 @@ describe('SearchService', () => {
       tokens: [],
       pools: [],
     });
+  });
+
+  it('ranks pools by volume descending then pool id for equal-volume ties', async () => {
+    prisma.$queryRawUnsafe.mockResolvedValue([]);
+    const service = new SearchService(prisma as never);
+
+    await service.search('usdc');
+
+    const poolSql = prisma.$queryRawUnsafe.mock.calls[1][0] as string;
+    expect(poolSql).toContain(
+      'LEFT JOIN "pool" pool ON pool."id" = p."poolId"',
+    );
+    expect(poolSql).toContain(
+      'COALESCE(NULLIF(pool."volume24h", \'\')::numeric, 0) DESC',
+    );
+    expect(poolSql).toContain('p."poolId" ASC');
+  });
+
+  it('documents a stable equal-volume fixture order (volume desc, poolId asc)', () => {
+    // Fixture mirrors the SQL ORDER BY contract for tied volumes.
+    const fixtures = [
+      { poolId: 'pool-b', volume24h: '1000' },
+      { poolId: 'pool-a', volume24h: '1000' },
+      { poolId: 'pool-c', volume24h: '5000' },
+    ];
+
+    const ranked = [...fixtures].sort((a, b) => {
+      const volumeDiff = Number(b.volume24h) - Number(a.volume24h);
+      return volumeDiff !== 0 ? volumeDiff : a.poolId.localeCompare(b.poolId);
+    });
+
+    expect(ranked.map((p) => p.poolId)).toEqual(['pool-c', 'pool-a', 'pool-b']);
   });
 });

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -99,6 +99,7 @@ export class SearchService {
         FROM "pool_created" p
         LEFT JOIN "token" token_a ON lower(token_a."address") = lower(p."tokenA")
         LEFT JOIN "token" token_b ON lower(token_b."address") = lower(p."tokenB")
+        LEFT JOIN "pool" pool ON pool."id" = p."poolId"
         WHERE
           lower(p."poolId") = lower($1)
           OR token_a."symbol" ILIKE $2
@@ -106,13 +107,7 @@ export class SearchService {
           OR p."tokenA" ILIKE $2
           OR p."tokenB" ILIKE $2
         ORDER BY
-          CASE
-            WHEN lower(p."poolId") = lower($1) THEN 0
-            WHEN lower(token_a."symbol") = lower($1) THEN 0
-            WHEN lower(token_b."symbol") = lower($1) THEN 0
-            WHEN token_a."symbol" ILIKE $2 OR token_b."symbol" ILIKE $2 THEN 1
-            ELSE 2
-          END,
+          COALESCE(NULLIF(pool."volume24h", '')::numeric, 0) DESC,
           p."poolId" ASC
         LIMIT 10
       `,


### PR DESCRIPTION
Task 1 — Indexer cursor advances only after successful write
Commit title: fix: advance indexer cursor only after successful write

Files: horizon.service.ts, horizon.service.spec.ts, indexer.spec.ts, indexer.worker.integration.spec.ts

PR description:

## Summary
- Stop Horizon from advancing the durable `indexer_cursor` after enqueue; only the worker advances it after a successful Postgres write
- Advance Horizon's in-memory paging token per ledger window only after that window's `addBulk` succeeds, so a mid-page enqueue failure does not skip ledgers
- Add regression coverage: failed write leaves checkpoint unchanged; successful write advances once; failed batch leaves durable cursor untouched
## Test plan
- [ ] `pnpm test -- --testPathPatterns=horizon.service.spec --testPathPatterns=indexer.worker.integration.spec`
- [ ] Confirm a failed worker upsert does not call `advanceLedger`
- [ ] Confirm a successful handler advances the checkpoint exactly once
- [ ] Confirm Horizon poll does not call `cursorService.advanceLedger` after enqueue
Task 2 — Indexer dead-letter replay is idempotent
Commit title: feat: add idempotent indexer dead-letter replay

Files: indexer-replay.service.ts, indexer-replay.service.spec.ts, indexer-dead-letter.service.ts, indexer.controller.ts, dto/replay-dead-letter.dto.ts, indexer.worker.integration.spec.ts (DLQ idempotency block), README.md

PR description:

## Summary
- Add `POST /indexer/dead-letters/replay` (internal key) to re-enqueue one DLQ job by `jobId`, or all unrecovered entries when omitted
- Use stable BullMQ job ids (`dlq-replay:<jobId>`) so a second replay is a no-op when the job still exists; worker upserts on `eventId` / pool / position keys keep projections safe
- Document replay API usage in Swagger + `apps/api/README.md`
- Integration test: processing the same swap DLQ payload twice leaves TVL/`volume24h` unchanged
## Test plan
- [ ] `pnpm test -- --testPathPatterns=indexer-replay.service.spec --testPathPatterns=indexer.worker.integration.spec`
- [ ] Call `POST /indexer/dead-letters/replay` with `{ "jobId": "…" }` twice; second call is no-op/upsert-safe
- [ ] Call with `{}` and confirm only unrecovered rows are enqueued
- [ ] Confirm pool TVL/volume do not double-apply on duplicate swap handling
Task 3 — API key rate limit returns standard error body
Commit title: fix: return standard ErrorResponse body on rate-limit 429

Files: rate-limit.middleware.ts, rate-limit.middleware.spec.ts

PR description:

## Summary
- Align rate-limit 429 JSON with `ErrorResponse` (`statusCode`, `message`, `error`, `timestamp`, `path`, optional `requestId`)
- Keep `Retry-After` header and include `retryAfter` in the body when available
- Add spec asserting 429 contract shape
## Test plan
- [ ] `pnpm test -- --testPathPatterns=rate-limit.middleware.spec`
- [ ] Exceed the global limit and verify 429 body matches the shared error contract
- [ ] Confirm `Retry-After` header and `retryAfter` field are present
Task 4 — Add search ranking fixture for equal-volume pools
Commit title: fix: rank search pools by volume then pool id

Files: search.service.ts, search.controller.ts, search.service.spec.ts

PR description:


## Summary
- Rank pool search results by `volume24h` DESC, then `poolId` ASC for stable equal-volume ties
- Join `pool_created` to `pool` for volume data
- Add equal-volume fixture + SQL ordering assertions; document ordering in Swagger
## Test plan
- [ ] `pnpm test -- --testPathPatterns=search.service.spec`
- [ ] Search with multiple equal-volume pools; order is stable by pool id
- [ ] Higher-volume pools rank above lower-volume matches
- [ ] Confirm Swagger notes volume-then-id ordering

closes #524 
closes #525 
closes #527 
closes #532