### PR TITLE
Add webhook retries, migrate smoke CI, math fixtures, and contracts CI.

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,43 @@
+name: Contracts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/contracts/**"
+      - ".github/workflows/contracts.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/contracts/**"
+      - ".github/workflows/contracts.yml"
+
+jobs:
+  contracts:
+    name: router + fee-collector
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/contracts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/contracts -> target
+
+      - name: cargo check fee-collector
+        run: cargo check -p swyft-fee-collector
+
+      - name: cargo check router
+        run: cargo check -p swyft-router
+
+      - name: cargo build (workspace release wasm)
+        run: cargo build --workspace --release --target wasm32-unknown-unknown

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -1,11 +1,20 @@
 name: Database Migrations
 
+# Prisma migration smoke against an ephemeral Postgres service.
+# Fails the job if migrate deploy errors (broken migration SQL / drift).
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
-      - "apps/api/prisma/**"
       - "prisma/**"
-      - "apps/api/package.json"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/db-migrations.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "prisma/**"
+      - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/db-migrations.yml"
 
@@ -13,7 +22,7 @@ jobs:
   db-migrations:
     name: db-migrations
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 10
 
     services:
       postgres:
@@ -55,7 +64,7 @@ jobs:
       - name: Generate Prisma client
         run: pnpm prisma generate --schema prisma/schema.prisma
 
-      - name: Apply migrations
+      - name: Apply migrations (smoke)
         run: pnpm prisma migrate deploy --schema prisma/schema.prisma
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/swyft_test?schema=public

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ docker-compose up -d --wait
 
 # 5. Initialize database (~30 sec)
 pnpm db:generate        # Generate Prisma client
-pnpm db:migrate:deploy  # Run migrations
+pnpm db:migrate:deploy  # Run migrations (same command CI uses for migrate smoke)
+
+# Local equivalent of the CI Prisma migration smoke
+# (.github/workflows/db-migrations.yml — ephemeral Postgres + migrate deploy):
+#   docker-compose up -d postgres   # or any Postgres 16 with DATABASE_URL set
+#   pnpm prisma migrate deploy --schema prisma/schema.prisma
+# This must succeed; a failing migrate fails CI on main/PRs that touch prisma/**.
 
 # 6. Start all dev servers (~2 min)
 pnpm dev

--- a/apps/api/src/webhooks/webhook-backoff.spec.ts
+++ b/apps/api/src/webhooks/webhook-backoff.spec.ts
@@ -1,0 +1,33 @@
+import {
+  WEBHOOK_RETRY_ATTEMPTS,
+  WEBHOOK_RETRY_BACKOFF_MS,
+  webhookBackoffDelayMs,
+  webhookBackoffSchedule,
+} from './webhook-backoff';
+
+describe('webhookBackoffSchedule', () => {
+  it('uses base delay of 2000ms by default', () => {
+    expect(WEBHOOK_RETRY_BACKOFF_MS).toBe(2000);
+  });
+
+  it('caps retries at WEBHOOK_RETRY_ATTEMPTS (default 3)', () => {
+    expect(WEBHOOK_RETRY_ATTEMPTS).toBe(3);
+    expect(webhookBackoffSchedule()).toHaveLength(3);
+  });
+
+  it('schedules exponential delays: 0, base, 2*base', () => {
+    expect(webhookBackoffSchedule(2000, 3)).toEqual([0, 2000, 4000]);
+  });
+
+  it('extends schedule when maxAttempts increases', () => {
+    expect(webhookBackoffSchedule(2000, 5)).toEqual([
+      0, 2000, 4000, 8000, 16000,
+    ]);
+  });
+
+  it('returns null for attempts outside 1..maxAttempts (retries stop at max)', () => {
+    expect(webhookBackoffDelayMs(0, 2000, 3)).toBeNull();
+    expect(webhookBackoffDelayMs(4, 2000, 3)).toBeNull();
+    expect(webhookBackoffDelayMs(3, 2000, 3)).toBe(4000);
+  });
+});

--- a/apps/api/src/webhooks/webhook-backoff.ts
+++ b/apps/api/src/webhooks/webhook-backoff.ts
@@ -1,0 +1,34 @@
+/** Base delay (ms) for BullMQ exponential backoff between delivery attempts. */
+export const WEBHOOK_RETRY_ATTEMPTS = Number(
+  process.env.WEBHOOK_RETRY_ATTEMPTS ?? '3',
+);
+export const WEBHOOK_RETRY_BACKOFF_MS = Number(
+  process.env.WEBHOOK_RETRY_BACKOFF_MS ?? '2000',
+);
+
+/**
+ * BullMQ exponential backoff delay for a given 1-based attempt number.
+ * Attempt 1 runs immediately (0 ms); subsequent attempts wait
+ * `baseDelayMs * 2^(attempt - 2)`.
+ *
+ * Retries stop once `attempt > maxAttempts` (job is not scheduled again).
+ */
+export function webhookBackoffDelayMs(
+  attempt: number,
+  baseDelayMs: number = WEBHOOK_RETRY_BACKOFF_MS,
+  maxAttempts: number = WEBHOOK_RETRY_ATTEMPTS,
+): number | null {
+  if (attempt < 1 || attempt > maxAttempts) return null;
+  if (attempt === 1) return 0;
+  return baseDelayMs * 2 ** (attempt - 2);
+}
+
+/** Full backoff schedule (ms) for attempts 1..maxAttempts. */
+export function webhookBackoffSchedule(
+  baseDelayMs: number = WEBHOOK_RETRY_BACKOFF_MS,
+  maxAttempts: number = WEBHOOK_RETRY_ATTEMPTS,
+): number[] {
+  return Array.from({ length: maxAttempts }, (_, i) =>
+    webhookBackoffDelayMs(i + 1, baseDelayMs, maxAttempts)!,
+  );
+}

--- a/apps/api/src/webhooks/webhook.processor.spec.ts
+++ b/apps/api/src/webhooks/webhook.processor.spec.ts
@@ -1,4 +1,9 @@
-import { WebhookWorker, WebhookJob } from './webhook.processor';
+import {
+  WebhookWorker,
+  WebhookJob,
+  WEBHOOK_RETRY_ATTEMPTS,
+  WEBHOOK_RETRY_BACKOFF_MS,
+} from './webhook.processor';
 import { PrismaService } from '../prisma/prisma.service';
 import { WebhookPayload } from './webhook.types';
 import { Job } from 'bullmq';
@@ -12,6 +17,9 @@ function buildMockPrisma() {
       update: jest.fn().mockResolvedValue({}),
     },
     webhookDelivery: {
+      create: jest.fn().mockResolvedValue({}),
+    },
+    webhookAuditLog: {
       create: jest.fn().mockResolvedValue({}),
     },
   };
@@ -28,6 +36,7 @@ function buildMockQueue() {
 
 const baseWebhook = {
   id: 'wh-1',
+  ownerWallet: 'GTESTOWNER',
   url: 'https://example.com/hook',
   secret: null as string | null,
   disabled: false,
@@ -40,8 +49,16 @@ const basePayload: WebhookPayload = {
   data: { poolId: 'pool-1', token0: 'XLM', token1: 'USDC' },
 };
 
-function makeJob(data: WebhookJob): Job<WebhookJob> {
-  return { data } as Job<WebhookJob>;
+function makeJob(
+  data: WebhookJob,
+  extras: Partial<Job<WebhookJob>> = {},
+): Job<WebhookJob> {
+  return {
+    data,
+    attemptsMade: 0,
+    opts: { attempts: WEBHOOK_RETRY_ATTEMPTS },
+    ...extras,
+  } as Job<WebhookJob>;
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -84,7 +101,19 @@ describe('WebhookWorker (dispatch integration)', () => {
       await worker.dispatch('wh-1', basePayload);
 
       const [, , opts] = (worker as any).queue.add.mock.calls[0];
-      expect(opts.backoff).toEqual({ type: 'exponential', delay: 2000 });
+      expect(opts.backoff).toEqual({
+        type: 'exponential',
+        delay: WEBHOOK_RETRY_BACKOFF_MS,
+      });
+      expect(opts.attempts).toBe(WEBHOOK_RETRY_ATTEMPTS);
+    });
+
+    it('stops retries at max attempts (no unbounded retries)', async () => {
+      await worker.dispatch('wh-1', basePayload);
+
+      const [, , opts] = (worker as any).queue.add.mock.calls[0];
+      expect(opts.attempts).toBe(3);
+      expect(opts.attempts).toBeLessThanOrEqual(WEBHOOK_RETRY_ATTEMPTS);
     });
 
     it('resolves without throwing on successful enqueue', async () => {
@@ -189,6 +218,52 @@ describe('WebhookWorker (dispatch integration)', () => {
           responseStatus: 200,
         }),
       });
+    });
+
+    it('records attempt count in the webhook audit log', async () => {
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await deliver({ webhookId: 'wh-1', payload: basePayload });
+
+      expect(prisma.webhookAuditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          webhookId: 'wh-1',
+          action: 'delivery_attempt',
+          ownerWallet: 'GTESTOWNER',
+          meta: expect.stringContaining('"attempt":1'),
+        }),
+      });
+      const meta = JSON.parse(
+        prisma.webhookAuditLog.create.mock.calls[0][0].data.meta,
+      );
+      expect(meta).toEqual(
+        expect.objectContaining({
+          attempt: 1,
+          maxAttempts: WEBHOOK_RETRY_ATTEMPTS,
+          success: true,
+          responseStatus: 200,
+        }),
+      );
+    });
+
+    it('increments audit attempt on BullMQ retries', async () => {
+      fetchSpy.mockResolvedValue({ status: 500 } as Response);
+      prisma.webhook.findUnique.mockResolvedValue(baseWebhook);
+
+      await expect(
+        (worker as any).deliver(
+          makeJob(
+            { webhookId: 'wh-1', payload: basePayload },
+            { attemptsMade: 1 },
+          ),
+        ),
+      ).rejects.toThrow(/Delivery failed/);
+
+      const meta = JSON.parse(
+        prisma.webhookAuditLog.create.mock.calls[0][0].data.meta,
+      );
+      expect(meta.attempt).toBe(2);
+      expect(meta.success).toBe(false);
     });
 
     it('resets consecutiveFails to 0 on success', async () => {

--- a/apps/api/src/webhooks/webhook.processor.ts
+++ b/apps/api/src/webhooks/webhook.processor.ts
@@ -8,13 +8,21 @@ import { Queue, Worker, Job } from 'bullmq';
 import { createHmac } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import { WebhookPayload } from './webhook.types';
+import {
+  WEBHOOK_RETRY_ATTEMPTS,
+  WEBHOOK_RETRY_BACKOFF_MS,
+} from './webhook-backoff';
+
+export {
+  WEBHOOK_RETRY_ATTEMPTS,
+  WEBHOOK_RETRY_BACKOFF_MS,
+  webhookBackoffDelayMs,
+  webhookBackoffSchedule,
+} from './webhook-backoff';
 
 export const WEBHOOK_QUEUE = 'webhook-delivery';
 const MAX_CONSECUTIVE_FAILS = Number(
   process.env.WEBHOOK_MAX_CONSECUTIVE_FAILS ?? '10',
-);
-const WEBHOOK_RETRY_ATTEMPTS = Number(
-  process.env.WEBHOOK_RETRY_ATTEMPTS ?? '3',
 );
 const REDIS_CONNECTION = {
   url: process.env.REDIS_URL ?? 'redis://localhost:6379',
@@ -70,7 +78,7 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
       { webhookId, payload },
       {
         attempts: WEBHOOK_RETRY_ATTEMPTS,
-        backoff: { type: 'exponential', delay: 2000 },
+        backoff: { type: 'exponential', delay: WEBHOOK_RETRY_BACKOFF_MS },
       },
     );
   }
@@ -90,6 +98,7 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
 
   private async deliver(job: Job<WebhookJob>): Promise<void> {
     const { webhookId, payload } = job.data;
+    const attempt = (job.attemptsMade ?? 0) + 1;
     const webhook = await this.prisma.webhook.findUnique({
       where: { id: webhookId },
     });
@@ -119,9 +128,27 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
 
     const deliveryMs = Date.now() - start;
     const success = responseStatus !== undefined && responseStatus < 400;
+    const maxAttempts = job.opts.attempts ?? WEBHOOK_RETRY_ATTEMPTS;
 
     await this.prisma.webhookDelivery.create({
       data: { webhookId, eventType: payload.event, responseStatus, deliveryMs },
+    });
+
+    // Record every delivery attempt in the webhook audit log (attempt count included).
+    await this.prisma.webhookAuditLog.create({
+      data: {
+        webhookId,
+        action: 'delivery_attempt',
+        ownerWallet: webhook.ownerWallet,
+        meta: JSON.stringify({
+          event: payload.event,
+          attempt,
+          maxAttempts,
+          responseStatus: responseStatus ?? null,
+          deliveryMs,
+          success,
+        }),
+      },
     });
 
     if (!success) {
@@ -146,7 +173,7 @@ export class WebhookWorker implements OnModuleInit, OnModuleDestroy {
       data: { consecutiveFails: 0 },
     });
     this.logger.log(
-      `Delivered ${payload.event} to ${webhookId} [${responseStatus}] in ${deliveryMs}ms`,
+      `Delivered ${payload.event} to ${webhookId} attempt=${attempt}/${maxAttempts} [${responseStatus}] in ${deliveryMs}ms`,
     );
   }
 }

--- a/docs/OPS_DEPLOYMENT.md
+++ b/docs/OPS_DEPLOYMENT.md
@@ -12,6 +12,21 @@ Swyft API supports two deployment models:
 | **Database** | PostgreSQL in container | Managed PostgreSQL (RDS, Cloud SQL) |
 | **Cache** | Redis in container | Managed Redis (ElastiCache, Memorystore) |
 | **Migrations** | Manual `pnpm db:migrate:deploy` | Blue-green or rolling deploy |
+
+### CI migration smoke (local equivalent)
+
+GitHub Actions runs Prisma migrate against ephemeral Postgres on main/PRs
+(`.github/workflows/db-migrations.yml`). Locally:
+
+```bash
+# Start Postgres (docker-compose or otherwise), then:
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/swyft_test?schema=public
+pnpm prisma migrate deploy --schema prisma/schema.prisma
+pnpm prisma migrate status --schema prisma/schema.prisma
+```
+
+Or simply: `pnpm db:migrate:deploy` with your local `DATABASE_URL` set.
+A failing migrate fails the CI job.
 | **Scaling** | Single instance | Multiple replicas with load balancer |
 | **Health checks** | Container health endpoint | HTTP `/health` probe |
 

--- a/fixtures/cl-math-vectors.json
+++ b/fixtures/cl-math-vectors.json
@@ -1,0 +1,47 @@
+{
+  "$schema_comment": "Shared concentrated-liquidity math vectors. tick_to_sqrt_price matches packages/contract/contracts/cl-pool (linear Q96 ± tick*Q96/20000). amounts_* assert @swyft/sdk position-math (Uniswap-style range-aware).",
+  "Q96": "79228162514264337593543950336",
+  "tick_to_sqrt_price": [
+    {
+      "tick": 0,
+      "sqrtPriceX96": "79228162514264337593543950336"
+    },
+    {
+      "tick": 100,
+      "sqrtPriceX96": "79624303326835659281511670087"
+    },
+    {
+      "tick": -100,
+      "sqrtPriceX96": "78832021701693015905576230585"
+    }
+  ],
+  "amounts_for_liquidity": [
+    {
+      "name": "in_range",
+      "sqrtPriceX96": "79228162514264337593543950336",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "10101",
+      "amount1": "9999"
+    },
+    {
+      "name": "below_range",
+      "sqrtPriceX96": "78435880889121694217608510832",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "20002",
+      "amount1": "0"
+    },
+    {
+      "name": "above_range",
+      "sqrtPriceX96": "80020444139406980969479389840",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "0",
+      "amount1": "19999"
+    }
+  ]
+}

--- a/packages/contract/contracts/cl-pool/src/lib.rs
+++ b/packages/contract/contracts/cl-pool/src/lib.rs
@@ -674,3 +674,28 @@ fn ensure_initialized(env: &Env) {
 fn panic_pool_error(env: &Env, error: PoolError) -> ! {
     env.panic_with_error(soroban_sdk::Error::from_contract_error(error as u32))
 }
+
+#[cfg(test)]
+mod fixture_tests {
+    use super::tick_to_sqrt_price;
+
+    /// Shared vectors from fixtures/cl-math-vectors.json (tick_to_sqrt_price).
+    /// Keep in sync with that file — see packages/sdk/README.md "Math fixture divergence".
+    #[test]
+    fn tick_to_sqrt_price_matches_shared_fixtures() {
+        let vectors: &[(i32, u128)] = &[
+            (0, 79228162514264337593543950336),
+            (100, 79624303326835659281511670087),
+            (-100, 78832021701693015905576230585),
+        ];
+        assert!(vectors.len() >= 3);
+        for &(tick, expected) in vectors {
+            assert_eq!(
+                tick_to_sqrt_price(tick),
+                expected,
+                "tick {tick} diverged from fixture"
+            );
+        }
+    }
+}
+

--- a/packages/contract/fixtures/cl-math-vectors.json
+++ b/packages/contract/fixtures/cl-math-vectors.json
@@ -1,0 +1,47 @@
+{
+  "$schema_comment": "Shared concentrated-liquidity math vectors. tick_to_sqrt_price matches packages/contract/contracts/cl-pool (linear Q96 ± tick*Q96/20000). amounts_* assert @swyft/sdk position-math (Uniswap-style range-aware).",
+  "Q96": "79228162514264337593543950336",
+  "tick_to_sqrt_price": [
+    {
+      "tick": 0,
+      "sqrtPriceX96": "79228162514264337593543950336"
+    },
+    {
+      "tick": 100,
+      "sqrtPriceX96": "79624303326835659281511670087"
+    },
+    {
+      "tick": -100,
+      "sqrtPriceX96": "78832021701693015905576230585"
+    }
+  ],
+  "amounts_for_liquidity": [
+    {
+      "name": "in_range",
+      "sqrtPriceX96": "79228162514264337593543950336",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "10101",
+      "amount1": "9999"
+    },
+    {
+      "name": "below_range",
+      "sqrtPriceX96": "78435880889121694217608510832",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "20002",
+      "amount1": "0"
+    },
+    {
+      "name": "above_range",
+      "sqrtPriceX96": "80020444139406980969479389840",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "0",
+      "amount1": "19999"
+    }
+  ]
+}

--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["fee-collector"]
+members = ["fee-collector", "router"]
 
 [workspace.package]
 edition = "2021"

--- a/packages/contracts/router/src/lib.rs
+++ b/packages/contracts/router/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+    Vec,
+};
 
 #[cfg(test)]
 extern crate std;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -147,6 +147,24 @@ const quote = getSwapQuote({
 
 ---
 
+## Math fixtures (contract parity)
+
+Liquidity / position math is pinned against shared golden vectors:
+
+- **Canonical file:** [`fixtures/cl-math-vectors.json`](../../fixtures/cl-math-vectors.json)
+- **Copies for package-local runs:** `packages/sdk/src/__tests__/fixtures/` and `packages/contract/fixtures/`
+- **SDK tests:** `src/__tests__/contract-math-fixtures.spec.ts` (requires ≥3 vectors to pass)
+- **Contract tests:** `cl-pool` `fixture_tests::tick_to_sqrt_price_matches_shared_fixtures`
+
+### Math fixture divergence process
+
+1. Prefer changing **one** source of truth: update `fixtures/cl-math-vectors.json`, then sync the package copies.
+2. Re-run SDK tests (`pnpm --filter @swyft/sdk test`) and `cargo test -p cl-pool` (or workspace) so both sides agree on `tick_to_sqrt_price`.
+3. `amounts_for_liquidity` vectors assert the **SDK** Uniswap-style range-aware formula. The on-chain `cl-pool` helper uses a simpler clamp-based variant — if those diverge intentionally, document the difference in the fixture `$schema_comment` and do **not** silently change expected amounts.
+4. Extreme ticks (e.g. `-20000`) may differ (`cl-pool` saturates to `0`, SDK floors to `1`). Keep shared vectors in the overlapping safe range unless both implementations are updated together.
+
+---
+
 ## Publishing
 
 Releases are automated via GitHub Actions. To publish a new version:

--- a/packages/sdk/src/__tests__/contract-math-fixtures.spec.ts
+++ b/packages/sdk/src/__tests__/contract-math-fixtures.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * SDK liquidity math vs shared contract fixtures (`fixtures/cl-math-vectors.json`).
+ *
+ * tick_to_sqrt_price vectors match cl-pool's linear approximation.
+ * amounts_for_liquidity vectors pin @swyft/sdk position-math outputs.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  Q96,
+  getAmountsForLiquidity,
+  tickToSqrtPriceX96,
+} from '../position-math';
+
+interface TickVector {
+  tick: number;
+  sqrtPriceX96: string;
+}
+
+interface AmountsVector {
+  name: string;
+  sqrtPriceX96: string;
+  sqrtPriceLowerX96: string;
+  sqrtPriceUpperX96: string;
+  liquidity: string;
+  amount0: string;
+  amount1: string;
+}
+
+interface ClMathFixtures {
+  Q96: string;
+  tick_to_sqrt_price: TickVector[];
+  amounts_for_liquidity: AmountsVector[];
+}
+
+function loadFixtures(): ClMathFixtures {
+  // Prefer monorepo root fixtures/ (shared with contracts); fall back to local copy.
+  const candidates = [
+    path.resolve(__dirname, '../../../../fixtures/cl-math-vectors.json'),
+    path.resolve(__dirname, './fixtures/cl-math-vectors.json'),
+  ];
+  for (const file of candidates) {
+    if (fs.existsSync(file)) {
+      return JSON.parse(fs.readFileSync(file, 'utf8')) as ClMathFixtures;
+    }
+  }
+  throw new Error('cl-math-vectors.json not found');
+}
+
+const fixtures = loadFixtures();
+
+describe('SDK liquidity math matches contract fixtures', () => {
+  it('shares the same Q96 constant', () => {
+    expect(Q96.toString()).toBe(fixtures.Q96);
+  });
+
+  it('passes at least 3 tick_to_sqrt_price fixture vectors', () => {
+    expect(fixtures.tick_to_sqrt_price.length).toBeGreaterThanOrEqual(3);
+
+    for (const vector of fixtures.tick_to_sqrt_price) {
+      expect(tickToSqrtPriceX96(vector.tick).toString()).toBe(vector.sqrtPriceX96);
+    }
+  });
+
+  it('passes at least 3 amounts_for_liquidity fixture vectors', () => {
+    expect(fixtures.amounts_for_liquidity.length).toBeGreaterThanOrEqual(3);
+
+    for (const vector of fixtures.amounts_for_liquidity) {
+      const { amount0, amount1 } = getAmountsForLiquidity({
+        sqrtPriceX96: BigInt(vector.sqrtPriceX96),
+        sqrtPriceLowerX96: BigInt(vector.sqrtPriceLowerX96),
+        sqrtPriceUpperX96: BigInt(vector.sqrtPriceUpperX96),
+        liquidity: BigInt(vector.liquidity),
+      });
+      expect({ name: vector.name, amount0: amount0.toString(), amount1: amount1.toString() }).toEqual({
+        name: vector.name,
+        amount0: vector.amount0,
+        amount1: vector.amount1,
+      });
+    }
+  });
+});

--- a/packages/sdk/src/__tests__/fixtures/cl-math-vectors.json
+++ b/packages/sdk/src/__tests__/fixtures/cl-math-vectors.json
@@ -1,0 +1,47 @@
+{
+  "$schema_comment": "Shared concentrated-liquidity math vectors. tick_to_sqrt_price matches packages/contract/contracts/cl-pool (linear Q96 ± tick*Q96/20000). amounts_* assert @swyft/sdk position-math (Uniswap-style range-aware).",
+  "Q96": "79228162514264337593543950336",
+  "tick_to_sqrt_price": [
+    {
+      "tick": 0,
+      "sqrtPriceX96": "79228162514264337593543950336"
+    },
+    {
+      "tick": 100,
+      "sqrtPriceX96": "79624303326835659281511670087"
+    },
+    {
+      "tick": -100,
+      "sqrtPriceX96": "78832021701693015905576230585"
+    }
+  ],
+  "amounts_for_liquidity": [
+    {
+      "name": "in_range",
+      "sqrtPriceX96": "79228162514264337593543950336",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "10101",
+      "amount1": "9999"
+    },
+    {
+      "name": "below_range",
+      "sqrtPriceX96": "78435880889121694217608510832",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "20002",
+      "amount1": "0"
+    },
+    {
+      "name": "above_range",
+      "sqrtPriceX96": "80020444139406980969479389840",
+      "sqrtPriceLowerX96": "78435880889121694217608510833",
+      "sqrtPriceUpperX96": "80020444139406980969479389839",
+      "liquidity": "1000000",
+      "amount0": "0",
+      "amount1": "19999"
+    }
+  ]
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -268,14 +268,14 @@ model IndexerCursor {
   @@map("indexer_cursor")
 }
 
-// #405 — Webhook CRUD audit log
-/// Immutable record of every create / update / delete operation on a Webhook.
+/// Immutable record of webhook lifecycle + delivery attempts.
+/// Actions: 'created' | 'updated' | 'deleted' | 'delivery_attempt'
 model WebhookAuditLog {
   id          String   @id @default(cuid())
   webhookId   String
-  action      String   // 'created' | 'updated' | 'deleted'
+  action      String
   ownerWallet String
-  /// JSON snapshot of the changed fields (url, eventTypes, etc.)
+  /// JSON snapshot (url/eventTypes for CRUD; attempt/maxAttempts for deliveries)
   meta        String   @default("{}")
   createdAt   DateTime @default(now())
 


### PR DESCRIPTION
 1 — Webhook delivery retries
Commit title: Add webhook retry backoff and delivery audit attempts

PR description:

## Summary
- Bounded BullMQ retries with exponential backoff (`WEBHOOK_RETRY_ATTEMPTS`, `WEBHOOK_RETRY_BACKOFF_MS`)
- Each delivery attempt writes `WebhookAuditLog` with `action: delivery_attempt` and `meta.attempt` / `maxAttempts`
- Unit-tested backoff schedule (`0, 2000, 4000` ms by default); attempts outside `1..max` return `null`
## Test plan
- [ ] `pnpm --filter api test -- --testPathPatterns=webhook-backoff.spec`
- [ ] `pnpm --filter api test -- --testPathPatterns=webhook.processor.spec` (needs working Prisma generate)
- [ ] Fail a webhook target → confirm retries stop at max and audit log shows attempt count


2 — Prisma migration smoke CI
Commit title: Smoke-test Prisma migrate in CI on ephemeral Postgres

PR description:

## Summary
- Hardens `.github/workflows/db-migrations.yml`: runs on `main` + PRs, path filter fixed to `prisma/**`, 10m timeout
- Job: Postgres 16 service → validate → generate → `migrate deploy` → `migrate status` (fails on migration error)
- Documents local equivalent in root `README.md` and `docs/OPS_DEPLOYMENT.md` (`pnpm db:migrate:deploy` / `prisma migrate deploy --schema prisma/schema.prisma`)
## Test plan
- [ ] Open a PR touching `prisma/**` and confirm `db-migrations` job is green
- [ ] Break a migration SQL locally and confirm `migrate deploy` fails
- [ ] Run local smoke: start Postgres, then `pnpm prisma migrate deploy --schema prisma/schema.prisma`

3 — SDK liquidity math fixtures
Commit title: Pin SDK liquidity math to shared contract fixtures

PR description:

## Summary
- Adds shared golden vectors at `fixtures/cl-math-vectors.json` (≥3 tick + ≥3 amounts cases), copied under SDK/contract packages
- SDK suite `contract-math-fixtures.spec.ts` asserts `tickToSqrtPriceX96` and `getAmountsForLiquidity`
- cl-pool Rust fixture test mirrors the three shared tick vectors
- SDK README documents vectors path + divergence process
## Test plan
- [x] `pnpm --filter @swyft/sdk test -- --testPathPatterns=contract-math-fixtures` (3 passed)
- [ ] `cargo test -p cl-pool fixture_tests` (or workspace equivalent)
- [ ] Confirm README links to `fixtures/cl-math-vectors.json`

4 — Contracts CI (router + fee-collector)
Commit title: CI cargo check for contracts router and fee-collector

PR description:

## Summary
- Adds `.github/workflows/contracts.yml`: `cargo check` for `swyft-router` and `swyft-fee-collector`, wasm release build, `Swatinem/rust-cache` on `target/`
- Adds `router` to `packages/contracts` workspace members
- Imports `panic_with_error` so router compiles (required for the job to be usable)
## Test plan
- [x] `cd packages/contracts && cargo check -p swyft-fee-collector -p swyft-router`
- [ ] Open a PR touching `packages/contracts/**` and confirm the Contracts workflow runs
- [ ] Introduce a compile error in either crate and confirm CI goes red
Note: Prefer splitting into 4 focused PRs from this branch (one commit/cherry-pick per task) — each checklist says keep the PR scoped to that issue only.

closes #526 
closes #533
closes #535 
closes #536