### PR TITLE
feat(indexer): persist swap fee amount from event payload

### DIFF
--- a/apps/api/src/indexer/indexer.spec.ts
+++ b/apps/api/src/indexer/indexer.spec.ts
@@ -48,7 +48,7 @@ const mockUpsert = () => jest.fn().mockResolvedValue({});
 
 const mockPrismaClient = {
   token: { upsert: mockUpsert() },
-  pool: { upsert: mockUpsert(), update: mockUpsert() },
+  pool: { upsert: mockUpsert(), update: mockUpsert(), findUnique: jest.fn().mockResolvedValue(null) },
   swap: { upsert: mockUpsert() },
   position: { upsert: mockUpsert() },
   poolCreated: { upsert: mockUpsert() },
@@ -724,6 +724,63 @@ describe('IndexerWorker', () => {
       await expect(handler(makeJob(data))).resolves.not.toThrow();
 
       expect(mockPrismaClient.swapProcessed.upsert).toHaveBeenCalled();
+    });
+
+    it('persists feeAmount from the event payload when provided', async () => {
+      const handler = getHandlerForQueue(QUEUE_NAMES.SWAP_PROCESSED);
+      await handler(makeJob({ ...data, feeAmount: '42.5' }));
+
+      expect(mockPrismaClient.swap.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            feeAmount: '42.5',
+          }),
+        }),
+      );
+    });
+
+    it('derives feeAmount from pool feeTier when event does not include it', async () => {
+      mockPrismaClient.pool.findUnique.mockResolvedValueOnce({ feeTier: 3000 });
+      const handler = getHandlerForQueue(QUEUE_NAMES.SWAP_PROCESSED);
+      await handler(makeJob(data));
+
+      // fee = |amount0| * (feeTier / 1_000_000) = 1000000 * 0.003 = 3000
+      expect(mockPrismaClient.swap.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            feeAmount: '3000',
+          }),
+        }),
+      );
+    });
+
+    it('defaults feeAmount to "0" when pool is not found and event has no fee', async () => {
+      mockPrismaClient.pool.findUnique.mockResolvedValueOnce(null);
+      const handler = getHandlerForQueue(QUEUE_NAMES.SWAP_PROCESSED);
+      await handler(makeJob(data));
+
+      expect(mockPrismaClient.swap.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            feeAmount: '0',
+          }),
+        }),
+      );
+    });
+
+    it('persists feeAmount even when sqrtPriceX96 is invalid', async () => {
+      const handler = getHandlerForQueue(QUEUE_NAMES.SWAP_PROCESSED);
+      await handler(
+        makeJob({ ...data, sqrtPriceX96: '0', feeAmount: '100' }),
+      );
+
+      expect(mockPrismaClient.swap.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            feeAmount: '100',
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -531,8 +531,35 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  /**
+   * Resolves the fee amount for a swap. Uses the event-level feeAmount when
+   * the upstream producer provides one; otherwise derives it from the pool's
+   * feeTier (parts-per-million applied to |amount0|).
+   */
+  private async resolveFeeAmount(d: SwapProcessedJobData): Promise<string> {
+    if (d.feeAmount !== undefined && d.feeAmount !== '') {
+      return d.feeAmount;
+    }
+    try {
+      const pool = await this.prisma.pool.findUnique({
+        where: { id: d.poolId },
+        select: { feeTier: true },
+      });
+      if (pool) {
+        const absAmount0 = Math.abs(Number(d.amount0));
+        const fee = absAmount0 * (pool.feeTier / 1_000_000);
+        return Number.isFinite(fee) ? String(fee) : '0';
+      }
+    } catch {
+      // Non-fatal: fee computation failure must not block swap persistence.
+    }
+    return '0';
+  }
+
   private async projectSwapProcessed(d: SwapProcessedJobData) {
     try {
+      const feeAmount = await this.resolveFeeAmount(d);
+
       if (!PoolsRepository.isValidSqrtPrice(d.sqrtPriceX96)) {
         this.logger.warn(
           `Skipping pool state update for swap ${d.eventId} — invalid sqrtPriceX96: "${d.sqrtPriceX96}"`,
@@ -552,6 +579,7 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
             sqrtPriceAfter: d.sqrtPriceX96,
             tickAfter: d.tick,
             transactionHash: d.transactionHash ?? d.eventId,
+            feeAmount,
             timestamp,
           },
         });
@@ -559,23 +587,6 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
       }
 
       const timestamp = d.timestamp ? new Date(d.timestamp) : new Date();
-
-      // Look up the pool's feeTier to compute the fee amount for this swap.
-      // feeTier is stored in parts-per-million (e.g. 3000 = 0.3%).
-      let feeAmount = '0';
-      try {
-        const pool = await this.prisma.pool.findUnique({
-          where: { id: d.poolId },
-          select: { feeTier: true },
-        });
-        if (pool) {
-          const absAmount0 = Math.abs(Number(d.amount0));
-          const fee = absAmount0 * (pool.feeTier / 1_000_000);
-          feeAmount = Number.isFinite(fee) ? String(fee) : '0';
-        }
-      } catch {
-        // Non-fatal: fee computation failure must not block swap persistence.
-      }
 
       await this.prisma.swap.upsert({
         where: { eventId: d.eventId },

--- a/apps/api/src/indexer/queues.ts
+++ b/apps/api/src/indexer/queues.ts
@@ -50,6 +50,8 @@ export interface SwapProcessedJobData extends IndexerJobData {
   tick: number;
   /** Transaction hash when Horizon exposes one; falls back to eventId. */
   transactionHash?: string;
+  /** Fee amount parsed directly from the on-chain event, when available. */
+  feeAmount?: string;
   /** ISO-8601 timestamp emitted by Horizon. */
   timestamp?: string;
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,8 @@ model Pool {
   swaps             Swap[]
   positions         Position[]
   priceCandles      PriceCandle[]
+  tvlAlertThresholds TvlAlertThreshold[]
+  tvlSnapshots      TvlSnapshot[]
 
   @@map("pool")
   @@index([token0Address, token1Address])


### PR DESCRIPTION
## Summary
- Add optional `feeAmount` field to `SwapProcessedJobData` so upstream events can carry the fee directly
- Extract fee resolution into `resolveFeeAmount()`: uses event-level fee when present, falls back to deriving from pool's `feeTier`
- Both valid and invalid-sqrtPrice code paths now persist `feeAmount` on indexed swaps
- Fix missing Prisma relation fields on Pool model for `TvlAlertThreshold` and `TvlSnapshot`

## Test plan
- [x] New test: event-level feeAmount is persisted when provided
- [x] New test: feeAmount derived from pool feeTier when event omits it
- [x] New test: feeAmount defaults to "0" when pool not found and no event fee
- [x] New test: feeAmount persisted even when sqrtPriceX96 is invalid
- [x] All 47 existing IndexerWorker tests continue to pass

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)