### PR TITLE
feat(web): AddLiquidity AmountInputs syncs ratio with range

### DIFF
--- a/apps/web/__tests__/useAddLiquidity.test.ts
+++ b/apps/web/__tests__/useAddLiquidity.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAddLiquidity, tickToPrice } from '@/hooks/useAddLiquidity';
+
+const mockPool = {
+  id: 'pool-1',
+  token0: { address: 'TOKEN0', symbol: 'XLM', name: 'Stellar', decimals: 7 },
+  token1: { address: 'TOKEN1', symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  token0Symbol: 'XLM',
+  token1Symbol: 'USDC',
+  feeTier: '0.30%',
+  currentPrice: 1.0,
+  currentTick: 0,
+  currentSqrtPrice: '79228162514264337593543950336',
+  totalLiquidity: '1000000',
+  tvl: 1000000,
+  volume24h: '500000',
+  volume7d: '3500000',
+  feeApr: 10.0,
+  creationTimestamp: 1700000000,
+  recentSwaps: [],
+};
+
+describe('useAddLiquidity — amount sync with range', () => {
+  it('recalculates amount1 when lowerTick changes and amount0 is set', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    const amount1Before = result.current.amount1;
+
+    act(() => result.current.setLowerTick(result.current.lowerTick - 120));
+
+    // amount0 should remain the same
+    expect(result.current.amount0).toBe('100');
+    // amount1 should have changed
+    expect(result.current.amount1).not.toBe(amount1Before);
+  });
+
+  it('recalculates amount1 when upperTick changes and amount0 is set', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    const amount1Before = result.current.amount1;
+
+    act(() => result.current.setUpperTick(result.current.upperTick + 120));
+
+    expect(result.current.amount0).toBe('100');
+    expect(result.current.amount1).not.toBe(amount1Before);
+  });
+
+  it('recalculates amount0 when range changes and amount1 was last edited', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount1('50'));
+
+    const amount0Before = result.current.amount0;
+
+    act(() => result.current.setLowerTick(result.current.lowerTick - 120));
+
+    // amount1 should remain as the user entered it
+    expect(result.current.amount1).toBe('50');
+    // amount0 should have been recalculated
+    expect(result.current.amount0).not.toBe(amount0Before);
+  });
+
+  it('recalculates amounts when setLowerPrice changes the range', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    const amount1Before = result.current.amount1;
+
+    act(() => result.current.setLowerPrice('0.5'));
+
+    expect(result.current.amount0).toBe('100');
+    expect(result.current.amount1).not.toBe(amount1Before);
+  });
+
+  it('recalculates amounts when setUpperPrice changes the range', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    const amount1Before = result.current.amount1;
+
+    act(() => result.current.setUpperPrice('2.0'));
+
+    expect(result.current.amount0).toBe('100');
+    expect(result.current.amount1).not.toBe(amount1Before);
+  });
+
+  it('recalculates amounts on setFullRange', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    // Use a non-symmetric price so the range change produces a different amount1
+    const asymmetricPool = { ...mockPool, currentPrice: 2.5 };
+    act(() => result.current.setPool(asymmetricPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    const amount1Before = result.current.amount1;
+
+    act(() => result.current.setFullRange());
+
+    expect(result.current.amount0).toBe('100');
+    // Full range changes the range dramatically, so amount1 should differ
+    expect(result.current.amount1).not.toBe(amount1Before);
+  });
+
+  it('does not change amounts when no amounts are entered', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+
+    // Both amounts should be empty
+    expect(result.current.amount0).toBe('');
+    expect(result.current.amount1).toBe('');
+
+    act(() => result.current.setLowerTick(result.current.lowerTick - 120));
+
+    expect(result.current.amount0).toBe('');
+    expect(result.current.amount1).toBe('');
+  });
+
+  it('clears amount1 when out-of-range (price below lower bound)', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    // Pool with currentPrice = 1.0
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    // Move lower tick above currentPrice so the position is out of range
+    // (currentPrice < lowerPrice means only token0 is needed, amount1 = 0)
+    const highTick = 6000; // tickToPrice(6000) ~ 1.82
+    act(() => result.current.setLowerTick(highTick));
+
+    // amount1 should be empty because it's out of range
+    expect(result.current.amount1).toBe('');
+  });
+
+  it('in-range deposit computes the second amount', () => {
+    const { result } = renderHook(() => useAddLiquidity());
+
+    act(() => result.current.setPool(mockPool as any));
+    act(() => result.current.setAmount0('100'));
+
+    // amount1 should be computed (non-empty for in-range)
+    expect(result.current.amount1).not.toBe('');
+    expect(parseFloat(result.current.amount1)).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/hooks/useAddLiquidity.ts
+++ b/apps/web/hooks/useAddLiquidity.ts
@@ -70,6 +70,9 @@ export interface AddLiquidityState {
   upperPrice: string;
   amount0: string;
   amount1: string;
+  /** Which amount field was last edited by the user — used to decide which
+   *  amount to recalculate when the range changes. */
+  lastEditedAmount: 'amount0' | 'amount1' | null;
   txStatus: TxStatus;
   txHash: string | null;
   txError: string | null;
@@ -85,6 +88,7 @@ const defaultState: AddLiquidityState = {
   upperPrice: '',
   amount0: '',
   amount1: '',
+  lastEditedAmount: null,
   txStatus: 'idle',
   txHash: null,
   txError: null,
@@ -96,6 +100,35 @@ export function useAddLiquidity() {
   const [state, setState] = useState<AddLiquidityState>(defaultState);
 
   const tickSpacing = state.pool ? feeToTickSpacing(state.pool.feeTier) : 60;
+
+  /**
+   * Recalculate the dependent amount after a range change. Uses
+   * `lastEditedAmount` to decide which amount the user considers the
+   * anchor so we only recalculate the other one.
+   */
+  function syncAmountsForRange(
+    s: AddLiquidityState,
+    newLowerTick: number,
+    newUpperTick: number,
+  ): Pick<AddLiquidityState, 'amount0' | 'amount1'> {
+    if (!s.pool) return { amount0: s.amount0, amount1: s.amount1 };
+    const lp = tickToPrice(newLowerTick);
+    const up = tickToPrice(newUpperTick);
+
+    if (s.lastEditedAmount === 'amount0') {
+      const n0 = parseFloat(s.amount0);
+      if (isNaN(n0) || n0 <= 0) return { amount0: s.amount0, amount1: s.amount1 };
+      const { amount1 } = calcAmounts(s.pool.currentPrice, lp, up, n0, null);
+      return { amount0: s.amount0, amount1: amount1 > 0 ? amount1.toFixed(7) : '' };
+    }
+    if (s.lastEditedAmount === 'amount1') {
+      const n1 = parseFloat(s.amount1);
+      if (isNaN(n1) || n1 <= 0) return { amount0: s.amount0, amount1: s.amount1 };
+      const { amount0 } = calcAmounts(s.pool.currentPrice, lp, up, null, n1);
+      return { amount0: amount0 > 0 ? amount0.toFixed(7) : '', amount1: s.amount1 };
+    }
+    return { amount0: s.amount0, amount1: s.amount1 };
+  }
 
   const setPool = useCallback((pool: PoolDetail) => {
     const spacing = feeToTickSpacing(pool.feeTier);
@@ -123,6 +156,7 @@ export function useAddLiquidity() {
         lowerTick: snapped,
         lowerPrice: tickToPrice(snapped).toFixed(6),
         isFullRange: false,
+        ...syncAmountsForRange(s, snapped, s.upperTick),
       }));
     },
     [tickSpacing]
@@ -136,6 +170,7 @@ export function useAddLiquidity() {
         upperTick: snapped,
         upperPrice: tickToPrice(snapped).toFixed(6),
         isFullRange: false,
+        ...syncAmountsForRange(s, s.lowerTick, snapped),
       }));
     },
     [tickSpacing]
@@ -147,7 +182,13 @@ export function useAddLiquidity() {
         const p = parseFloat(price);
         const tick =
           isNaN(p) || p <= 0 ? s.lowerTick : nearestUsableTick(priceToTick(p), tickSpacing);
-        return { ...s, lowerPrice: price, lowerTick: tick, isFullRange: false };
+        return {
+          ...s,
+          lowerPrice: price,
+          lowerTick: tick,
+          isFullRange: false,
+          ...syncAmountsForRange(s, tick, s.upperTick),
+        };
       });
     },
     [tickSpacing]
@@ -159,7 +200,13 @@ export function useAddLiquidity() {
         const p = parseFloat(price);
         const tick =
           isNaN(p) || p <= 0 ? s.upperTick : nearestUsableTick(priceToTick(p), tickSpacing);
-        return { ...s, upperPrice: price, upperTick: tick, isFullRange: false };
+        return {
+          ...s,
+          upperPrice: price,
+          upperTick: tick,
+          isFullRange: false,
+          ...syncAmountsForRange(s, s.lowerTick, tick),
+        };
       });
     },
     [tickSpacing]
@@ -167,9 +214,9 @@ export function useAddLiquidity() {
 
   const setAmount0 = useCallback((val: string) => {
     setState((s) => {
-      if (!s.pool) return { ...s, amount0: val };
+      if (!s.pool) return { ...s, amount0: val, lastEditedAmount: 'amount0' };
       const n = parseFloat(val);
-      if (isNaN(n) || n <= 0) return { ...s, amount0: val, amount1: '' };
+      if (isNaN(n) || n <= 0) return { ...s, amount0: val, amount1: '', lastEditedAmount: 'amount0' };
       const { amount1 } = calcAmounts(
         s.pool.currentPrice,
         tickToPrice(s.lowerTick),
@@ -177,15 +224,15 @@ export function useAddLiquidity() {
         n,
         null
       );
-      return { ...s, amount0: val, amount1: amount1 > 0 ? amount1.toFixed(7) : '' };
+      return { ...s, amount0: val, amount1: amount1 > 0 ? amount1.toFixed(7) : '', lastEditedAmount: 'amount0' };
     });
   }, []);
 
   const setAmount1 = useCallback((val: string) => {
     setState((s) => {
-      if (!s.pool) return { ...s, amount1: val };
+      if (!s.pool) return { ...s, amount1: val, lastEditedAmount: 'amount1' };
       const n = parseFloat(val);
-      if (isNaN(n) || n <= 0) return { ...s, amount1: val, amount0: '' };
+      if (isNaN(n) || n <= 0) return { ...s, amount1: val, amount0: '', lastEditedAmount: 'amount1' };
       const { amount0 } = calcAmounts(
         s.pool.currentPrice,
         tickToPrice(s.lowerTick),
@@ -193,19 +240,24 @@ export function useAddLiquidity() {
         null,
         n
       );
-      return { ...s, amount1: val, amount0: amount0 > 0 ? amount0.toFixed(7) : '' };
+      return { ...s, amount1: val, amount0: amount0 > 0 ? amount0.toFixed(7) : '', lastEditedAmount: 'amount1' };
     });
   }, []);
 
   const setFullRange = useCallback(() => {
-    setState((s) => ({
-      ...s,
-      lowerTick: MIN_TICK,
-      upperTick: MAX_TICK,
-      lowerPrice: '0.000001',
-      upperPrice: '999999',
-      isFullRange: true,
-    }));
+    setState((s) => {
+      const newLower = MIN_TICK;
+      const newUpper = MAX_TICK;
+      return {
+        ...s,
+        lowerTick: newLower,
+        upperTick: newUpper,
+        lowerPrice: '0.000001',
+        upperPrice: '999999',
+        isFullRange: true,
+        ...syncAmountsForRange(s, newLower, newUpper),
+      };
+    });
   }, []);
 
   const submit = useCallback(

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,8 @@ model Pool {
   swaps             Swap[]
   positions         Position[]
   priceCandles      PriceCandle[]
+  tvlAlertThresholds TvlAlertThreshold[]
+  tvlSnapshots      TvlSnapshot[]
 
   @@map("pool")
   @@index([token0Address, token1Address])


### PR DESCRIPTION
## Summary
- Add `syncAmountsForRange()` to `useAddLiquidity` that recalculates the dependent amount when the price range changes
- Track `lastEditedAmount` to determine which amount is the user's anchor and which should be recalculated
- Range changes via `setLowerTick`, `setUpperTick`, `setLowerPrice`, `setUpperPrice`, and `setFullRange` all trigger the sync

## Test plan
- [x] New test: recalculates amount1 when lowerTick changes and amount0 is set
- [x] New test: recalculates amount1 when upperTick changes and amount0 is set
- [x] New test: recalculates amount0 when range changes and amount1 was last edited
- [x] New test: recalculates on setLowerPrice change
- [x] New test: recalculates on setUpperPrice change
- [x] New test: recalculates on setFullRange
- [x] New test: no change when no amounts are entered
- [x] New test: out-of-range clears amount1
- [x] New test: in-range deposit computes second amount

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)