### PR TITLE
test(api): cover privileged action auditing

### DIFF
--- a/apps/api/src/admin/admin-audit.interceptor.spec.ts
+++ b/apps/api/src/admin/admin-audit.interceptor.spec.ts
@@ -1,0 +1,43 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { lastValueFrom, of } from 'rxjs';
+import { AdminAuditInterceptor } from './admin-audit.interceptor';
+import { AdminAuditService } from './admin-audit.service';
+
+describe('AdminAuditInterceptor', () => {
+  it('audits a successful privileged action without storing the raw key', async () => {
+    const auditService = { log: jest.fn().mockResolvedValue(undefined) };
+    const request = {
+      method: 'GET',
+      path: '/admin/analytics/overview',
+      query: {},
+      ip: '127.0.0.1',
+      headers: { 'x-internal-key': 'do-not-store-me' },
+    };
+    const response = { statusCode: 200 };
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as unknown as ExecutionContext;
+    const next = { handle: () => of({ ok: true }) } as CallHandler;
+
+    await lastValueFrom(
+      new AdminAuditInterceptor(
+        auditService as unknown as AdminAuditService,
+      ).intercept(context, next),
+    );
+    await Promise.resolve();
+
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'GET /admin/analytics/overview',
+        resource: 'analytics',
+        statusCode: 200,
+      }),
+    );
+    expect(auditService.log.mock.calls[0][0].actor).not.toContain(
+      'do-not-store-me',
+    );
+  });
+});

--- a/apps/api/src/admin/admin-audit.service.spec.ts
+++ b/apps/api/src/admin/admin-audit.service.spec.ts
@@ -1,0 +1,53 @@
+import { AdminAuditService } from './admin-audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('AdminAuditService', () => {
+  const create = jest.fn();
+  const findMany = jest.fn();
+  const prisma = {
+    adminAuditLog: { create, findMany },
+  } as unknown as PrismaService;
+  const service = new AdminAuditService(prisma);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists the actor, action, resource, and metadata', async () => {
+    create.mockResolvedValue({ id: 'audit-1' });
+
+    await service.log({
+      actor: 'admin-key-fingerprint',
+      action: 'GET /admin/analytics/overview',
+      resource: 'analytics',
+      meta: { query: { interval: '1d' } },
+      ip: '127.0.0.1',
+      statusCode: 200,
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        actor: 'admin-key-fingerprint',
+        action: 'GET /admin/analytics/overview',
+        resource: 'analytics',
+        meta: JSON.stringify({ query: { interval: '1d' } }),
+        ip: '127.0.0.1',
+        statusCode: 200,
+      },
+    });
+  });
+
+  it('provides a bounded, newest-first audit query path', async () => {
+    findMany.mockResolvedValue([]);
+
+    await service.findRecent(1000, 25);
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { createdAt: 'desc' },
+        take: 500,
+        skip: 25,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- verify privileged actions persist actor, action, resource, and metadata
- cover the bounded newest-first audit query path
- verify raw internal keys are never stored

## Related issue

- Closes #561

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [ ] Docs updated if needed