### PR TITLE
feat(api): record TVL threshold breaches

### DIFF
--- a/apps/api/src/stats/tvl-alert.service.spec.ts
+++ b/apps/api/src/stats/tvl-alert.service.spec.ts
@@ -28,6 +28,9 @@ describe('TvlAlertService', () => {
               upsert: jest.fn(),
               findMany: jest.fn(),
             },
+            tvlAlertHistory: {
+              create: jest.fn(),
+            },
           },
         },
         {
@@ -144,6 +147,17 @@ describe('TvlAlertService', () => {
 
       await service.checkAndTriggerAlerts(mockPool, 900000);
 
+      expect(prisma.tvlAlertHistory.create).toHaveBeenCalledWith({
+        data: {
+          thresholdId: 'threshold-1',
+          poolId: 'pool-1',
+          ownerWallet: 'owner-1',
+          thresholdUsd: 1000000,
+          observedTvlUsd: 900000,
+          direction: 'below',
+          breachedAt: expect.any(Date),
+        },
+      });
       expect(prisma.tvlAlertThreshold.update).toHaveBeenCalledWith({
         where: { id: 'threshold-1' },
         data: { lastTriggeredAt: expect.any(Date) },

--- a/apps/api/src/stats/tvl-alert.service.ts
+++ b/apps/api/src/stats/tvl-alert.service.ts
@@ -134,10 +134,23 @@ export class TvlAlertService {
 
     for (const threshold of thresholds) {
       try {
+        const breachedAt = new Date();
+        await this.prisma.tvlAlertHistory.create({
+          data: {
+            thresholdId: threshold.id,
+            poolId: pool.id,
+            ownerWallet: threshold.ownerWallet,
+            thresholdUsd: threshold.thresholdUsd,
+            observedTvlUsd: currentTvlUsd,
+            direction: threshold.direction,
+            breachedAt,
+          },
+        });
+
         // Update last triggered time
         await this.prisma.tvlAlertThreshold.update({
           where: { id: threshold.id },
-          data: { lastTriggeredAt: new Date() },
+          data: { lastTriggeredAt: breachedAt },
         });
 
         // Trigger webhook if user has webhooks set up for pool.tvl.milestone
@@ -148,7 +161,7 @@ export class TvlAlertService {
           tvlUsd: currentTvlUsd,
           threshold: threshold.thresholdUsd,
           direction: threshold.direction,
-          crossedAt: new Date().toISOString(),
+          crossedAt: breachedAt.toISOString(),
         });
 
         this.logger.log(

--- a/prisma/migrations/20260728000000_add_tvl_alert_breach_history/migration.sql
+++ b/prisma/migrations/20260728000000_add_tvl_alert_breach_history/migration.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "tvl_alert_history" (
+    "id" TEXT NOT NULL,
+    "threshold_id" TEXT NOT NULL,
+    "pool_id" TEXT NOT NULL,
+    "owner_wallet" TEXT NOT NULL,
+    "threshold_usd" DOUBLE PRECISION NOT NULL,
+    "observed_tvl_usd" DOUBLE PRECISION NOT NULL,
+    "direction" TEXT NOT NULL,
+    "breached_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tvl_alert_history_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "tvl_alert_history_threshold_id_breached_at_idx"
+    ON "tvl_alert_history"("threshold_id", "breached_at");
+
+CREATE INDEX "tvl_alert_history_pool_id_breached_at_idx"
+    ON "tvl_alert_history"("pool_id", "breached_at");
+
+ALTER TABLE "tvl_alert_history"
+    ADD CONSTRAINT "tvl_alert_history_threshold_id_fkey"
+    FOREIGN KEY ("threshold_id") REFERENCES "tvl_alert_threshold"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -343,11 +343,30 @@ model TvlAlertThreshold {
   updatedAt        DateTime @updatedAt
 
   pool             Pool     @relation(fields: [poolId], references: [id], onDelete: Cascade)
+  history          TvlAlertHistory[]
 
   @@unique([poolId, ownerWallet])
   @@index([poolId])
   @@index([ownerWallet])
   @@map("tvl_alert_threshold")
+}
+
+/// Immutable history of threshold breaches, retained independently of delivery.
+model TvlAlertHistory {
+  id             String   @id @default(cuid())
+  thresholdId    String
+  poolId         String
+  ownerWallet    String
+  thresholdUsd   Float
+  observedTvlUsd Float
+  direction      String
+  breachedAt     DateTime @default(now())
+
+  threshold TvlAlertThreshold @relation(fields: [thresholdId], references: [id], onDelete: Cascade)
+
+  @@index([thresholdId, breachedAt])
+  @@index([poolId, breachedAt])
+  @@map("tvl_alert_history")
 }
 
 /// #489 — Historical TVL time series


### PR DESCRIPTION
## Summary

- persist an immutable history row for each eligible TVL breach
- retain the existing 24-hour anti-spam cooldown
- add the history model, indexes, migration, and regression coverage

## Related issue

- Closes #562

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [ ] Docs updated if needed