### PR TITLE
fix(api): support paginated token prefix search

### DIFF
--- a/apps/api/src/search/search.controller.spec.ts
+++ b/apps/api/src/search/search.controller.spec.ts
@@ -18,7 +18,7 @@ describe('SearchController', () => {
     );
 
     await expect(controller.search('usdc')).resolves.toBe(response);
-    expect(searchService.search).toHaveBeenCalledWith('usdc');
+    expect(searchService.search).toHaveBeenCalledWith('usdc', 10, 0);
   });
 
   it('defaults the query to an empty string when none is provided', async () => {
@@ -28,6 +28,16 @@ describe('SearchController', () => {
     );
 
     await controller.search(undefined);
-    expect(searchService.search).toHaveBeenCalledWith('');
+    expect(searchService.search).toHaveBeenCalledWith('', 10, 0);
+  });
+
+  it('passes pagination parameters as numbers', async () => {
+    searchService.search.mockResolvedValueOnce({ tokens: [], pools: [] });
+    const controller = new SearchController(
+      searchService as unknown as SearchService,
+    );
+
+    await controller.search('usd', '25', '50');
+    expect(searchService.search).toHaveBeenCalledWith('usd', 25, 50);
   });
 });

--- a/apps/api/src/search/search.controller.ts
+++ b/apps/api/src/search/search.controller.ts
@@ -20,12 +20,18 @@ export class SearchController {
     description: 'Search query (min 2 characters)',
     example: 'USDC',
   })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, example: 0 })
   @ApiResponse({
     status: 200,
     description:
       'Matching tokens and pools. Pools ordered by volume24h DESC, then poolId ASC.',
   })
-  search(@Query('q') query = ''): Promise<SearchResponse> {
-    return this.searchService.search(query);
+  search(
+    @Query('q') query = '',
+    @Query('limit') limit = '10',
+    @Query('offset') offset = '0',
+  ): Promise<SearchResponse> {
+    return this.searchService.search(query, Number(limit), Number(offset));
   }
 }

--- a/apps/api/src/search/search.service.spec.ts
+++ b/apps/api/src/search/search.service.spec.ts
@@ -64,7 +64,7 @@ describe('SearchService', () => {
     expect(tokenSql).toContain('WHEN "name" ILIKE $3 THEN 2');
   });
 
-  it('full-text searches the token symbol via to_tsvector/websearch_to_tsquery', async () => {
+  it('full-text searches token symbol prefixes through the GIN expression', async () => {
     prisma.$queryRawUnsafe.mockResolvedValue([]);
     const service = new SearchService(prisma as never);
 
@@ -73,9 +73,19 @@ describe('SearchService', () => {
     const tokenSql = prisma.$queryRawUnsafe.mock.calls[0][0] as string;
     const tokenArgs = prisma.$queryRawUnsafe.mock.calls[0].slice(1);
     expect(tokenSql).toContain(
-      `to_tsvector('simple', "symbol") @@ websearch_to_tsquery('simple', $4)`,
+      `to_tsvector('simple', "symbol") @@ to_tsquery('simple', $4)`,
     );
-    expect(tokenArgs).toEqual(['usdc', 'usdc%', '%usdc%', 'usdc']);
+    expect(tokenArgs).toEqual(['usdc', 'usdc%', '%usdc%', 'usdc:*', 10, 0]);
+  });
+
+  it('clamps pagination and passes it to both indexed queries', async () => {
+    prisma.$queryRawUnsafe.mockResolvedValue([]);
+    const service = new SearchService(prisma as never);
+
+    await service.search('usd', 1000, 20);
+
+    expect(prisma.$queryRawUnsafe.mock.calls[0].slice(-2)).toEqual([50, 20]);
+    expect(prisma.$queryRawUnsafe.mock.calls[1].slice(-2)).toEqual([50, 20]);
   });
 
   it('returns empty arrays when no matches are found', async () => {

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -27,21 +27,34 @@ export interface SearchResponse {
 export class SearchService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async search(rawQuery: string): Promise<SearchResponse> {
+  async search(
+    rawQuery: string,
+    rawLimit = 10,
+    rawOffset = 0,
+  ): Promise<SearchResponse> {
     const query = rawQuery.trim();
     if (query.length < 2) {
       return { tokens: [], pools: [] };
     }
+    const limit = Math.min(Math.max(Math.trunc(rawLimit) || 10, 1), 50);
+    const offset = Math.max(Math.trunc(rawOffset) || 0, 0);
 
     const [tokens, pools] = await Promise.all([
-      this.searchTokens(query),
-      this.searchPools(query),
+      this.searchTokens(query, limit, offset),
+      this.searchPools(query, limit, offset),
     ]);
 
     return { tokens, pools };
   }
 
-  private searchTokens(query: string): Promise<SearchTokenResult[]> {
+  private searchTokens(
+    query: string,
+    limit: number,
+    offset: number,
+  ): Promise<SearchTokenResult[]> {
+    const tsPrefix = (query.toLowerCase().match(/[a-z0-9]+/g) ?? [])
+      .map((term) => `${term}:*`)
+      .join(' & ');
     return (
       this.prisma.$queryRawUnsafe as (
         sql: string,
@@ -60,28 +73,37 @@ export class SearchService {
           lower("address") = lower($1)
           OR "symbol" ILIKE $2
           OR "name" ILIKE $3
-          OR to_tsvector('simple', "symbol") @@ websearch_to_tsquery('simple', $4)
+          OR (
+            $4 <> ''
+            AND to_tsvector('simple', "symbol") @@ to_tsquery('simple', $4)
+          )
         ORDER BY
           CASE
             WHEN lower("symbol") = lower($1) THEN 0
             WHEN lower("address") = lower($1) THEN 0
             WHEN "symbol" ILIKE $2 THEN 1
-            WHEN to_tsvector('simple', "symbol") @@ websearch_to_tsquery('simple', $4) THEN 1
+            WHEN $4 <> '' AND to_tsvector('simple', "symbol") @@ to_tsquery('simple', $4) THEN 1
             WHEN "name" ILIKE $3 THEN 2
             ELSE 3
           END,
           "symbol" ASC,
           "name" ASC
-        LIMIT 10
+        LIMIT $5 OFFSET $6
       `,
       query,
       `${query}%`,
       `%${query}%`,
-      query,
+      tsPrefix,
+      limit,
+      offset,
     );
   }
 
-  private searchPools(query: string): Promise<SearchPoolResult[]> {
+  private searchPools(
+    query: string,
+    limit: number,
+    offset: number,
+  ): Promise<SearchPoolResult[]> {
     return (
       this.prisma.$queryRawUnsafe as (
         sql: string,
@@ -109,10 +131,12 @@ export class SearchService {
         ORDER BY
           COALESCE(NULLIF(pool."volume24h", '')::numeric, 0) DESC,
           p."poolId" ASC
-        LIMIT 10
+        LIMIT $3 OFFSET $4
       `,
       query,
       `${query}%`,
+      limit,
+      offset,
     );
   }
 }


### PR DESCRIPTION
## Summary

- use the token symbol GIN expression for safe prefix queries
- add bounded limit and offset pagination
- cover prefix arguments, empty-query guards, and pagination

## Related issue

- Closes #563

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [ ] Docs updated if needed