### PR TITLE
fix(api): make demo pool seed deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ docker-compose up -d --wait
 pnpm db:generate        # Generate Prisma client
 pnpm db:migrate:deploy  # Run migrations (same command CI uses for migrate smoke)
 
+# Optional: load the deterministic demo market used by the web app
+pnpm --filter api exec ts-node ../../prisma/seed.ts
+
 # Local equivalent of the CI Prisma migration smoke
 # (.github/workflows/db-migrations.yml — ephemeral Postgres + migrate deploy):
 #   docker-compose up -d postgres   # or any Postgres 16 with DATABASE_URL set
@@ -93,6 +96,10 @@ pnpm dev
 ```
 
 This starts the Next.js dApp, NestJS API, and watches contract changes simultaneously via Turborepo.
+
+The seed is safe to re-run. It keeps the demo pool at `test-pool-1`, using
+USDC address `GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`
+and XLM address `GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR`.
 
 **Total time: ~5 minutes** (mostly waiting for pnpm install and Docker)
 

--- a/apps/api/src/seed.spec.ts
+++ b/apps/api/src/seed.spec.ts
@@ -126,6 +126,7 @@ describe('prisma seed', () => {
     await runSeed();
     expect(mockCreateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        skipDuplicates: true,
         data: expect.arrayContaining([
           expect.objectContaining({ transactionHash: 'test-tx-1' }),
           expect.objectContaining({ transactionHash: 'test-tx-2' }),
@@ -138,8 +139,13 @@ describe('prisma seed', () => {
     await runSeed();
     expect(mockCreateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        skipDuplicates: true,
         data: expect.arrayContaining([
-          expect.objectContaining({ poolId: 'test-pool-1', interval: '1h' }),
+          expect.objectContaining({
+            poolId: 'test-pool-1',
+            interval: '1h',
+            periodStart: new Date('2026-01-01T00:00:00.000Z'),
+          }),
         ]),
       }),
     );

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -149,6 +149,7 @@ export async function main() {
 
     await prisma.swap.createMany({
       data: swapData,
+      skipDuplicates: true,
     });
     spinner.stop(true, 'Swaps seeded   (2 records)');
 
@@ -162,13 +163,14 @@ export async function main() {
         low: 0.95,
         close: 1.02,
         volumeUsd: 1000000.0,
-        periodStart: new Date(),
+        periodStart: new Date('2026-01-01T00:00:00.000Z'),
         interval: '1h',
       },
     ];
 
     await prisma.priceCandle.createMany({
       data: priceCandleData,
+      skipDuplicates: true,
     });
     spinner.stop(true, 'Price candles seeded (1 record)');
 


### PR DESCRIPTION
## Summary

- skip duplicate seeded swaps and candles on repeated runs
- use a stable candle timestamp for deterministic upserts
- document the demo pool and token addresses

## Related issue

- Closes #557

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [x] Docs updated if needed