### PR TITLE
fix(api): guard response compression

### DIFF
--- a/apps/api/src/compression.middleware.spec.ts
+++ b/apps/api/src/compression.middleware.spec.ts
@@ -1,0 +1,74 @@
+import { CompressionMiddleware } from './compression.middleware';
+
+function response(contentType: string, contentEncoding?: string) {
+  const headers = new Map<string, string>();
+  headers.set('Content-Type', contentType);
+  if (contentEncoding) headers.set('Content-Encoding', contentEncoding);
+
+  const chunks: Buffer[] = [];
+  const res = {
+    write: jest.fn((chunk: Buffer) => {
+      chunks.push(Buffer.from(chunk));
+      return true;
+    }),
+    end: jest.fn((chunk?: Buffer) => {
+      if (chunk) chunks.push(Buffer.from(chunk));
+      return res;
+    }),
+    getHeader: jest.fn((name: string) => headers.get(name)),
+    setHeader: jest.fn((name: string, value: string) =>
+      headers.set(name, value),
+    ),
+    removeHeader: jest.fn((name: string) => headers.delete(name)),
+    vary: jest.fn(),
+  };
+
+  return { res, headers, chunks };
+}
+
+describe('CompressionMiddleware', () => {
+  const body = Buffer.alloc(2048, 'a');
+
+  it('leaves already-compressed responses unchanged', () => {
+    const { res, headers, chunks } = response('application/json', 'gzip');
+    const next = jest.fn(() => res.end(body));
+
+    new CompressionMiddleware().use(
+      { headers: { 'accept-encoding': 'br' }, path: '/v1/pools' } as never,
+      res as never,
+      next,
+    );
+
+    expect(Buffer.concat(chunks)).toEqual(body);
+    expect(headers.get('Content-Encoding')).toBe('gzip');
+  });
+
+  it('does not compress binary responses', () => {
+    const { res, headers, chunks } = response('application/octet-stream');
+    const next = jest.fn(() => res.end(body));
+
+    new CompressionMiddleware().use(
+      { headers: { 'accept-encoding': 'gzip' }, path: '/download' } as never,
+      res as never,
+      next,
+    );
+
+    expect(Buffer.concat(chunks)).toEqual(body);
+    expect(headers.has('Content-Encoding')).toBe(false);
+  });
+
+  it('does not intercept health responses', () => {
+    const { res } = response('application/json');
+    const originalEnd = res.end;
+    const next = jest.fn();
+
+    new CompressionMiddleware().use(
+      { headers: { 'accept-encoding': 'gzip' }, path: '/health' } as never,
+      res as never,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.end).toBe(originalEnd);
+  });
+});

--- a/apps/api/src/compression.middleware.ts
+++ b/apps/api/src/compression.middleware.ts
@@ -9,6 +9,20 @@ import {
 const MIN_SIZE = 1024; // 1 KB
 const LEVEL = Number(process.env.COMPRESSION_LEVEL ?? 6);
 
+function isCompressible(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+  const type = contentType.split(';', 1)[0].trim().toLowerCase();
+  return (
+    type.startsWith('text/') ||
+    type === 'application/json' ||
+    type.endsWith('+json') ||
+    type === 'application/javascript' ||
+    type === 'application/xml' ||
+    type.endsWith('+xml') ||
+    type === 'image/svg+xml'
+  );
+}
+
 @Injectable()
 export class CompressionMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction) {
@@ -41,8 +55,19 @@ export class CompressionMiddleware implements NestMiddleware {
           Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string),
         );
       const body = Buffer.concat(chunks);
+      const contentEncoding = res.getHeader('Content-Encoding');
+      const contentType = res.getHeader('Content-Type');
+      const normalizedContentType = Array.isArray(contentType)
+        ? contentType[0]
+        : typeof contentType === 'string'
+          ? contentType
+          : undefined;
 
-      if (body.length < MIN_SIZE) {
+      if (
+        body.length < MIN_SIZE ||
+        (contentEncoding && contentEncoding !== 'identity') ||
+        !isCompressible(normalizedContentType)
+      ) {
         // Too small — send uncompressed
         res.write = originalWrite;
         res.end = originalEnd;
@@ -50,6 +75,7 @@ export class CompressionMiddleware implements NestMiddleware {
         return res;
       }
 
+      res.vary('Accept-Encoding');
       if (preferBrotli) {
         res.setHeader('Content-Encoding', 'br');
         res.removeHeader('Content-Length');


### PR DESCRIPTION
## Summary

- pass through already encoded responses unchanged
- skip binary and small payloads while preserving health responses
- add regression coverage for compression guards

## Related issue

- Closes #558

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [ ] Docs updated if needed