### PR TITLE
fix(api): isolate Horizon polling failures

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,7 @@ REDIS_URL=redis://localhost:6379
 STELLAR_NETWORK=testnet
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 HORIZON_URL=https://horizon-testnet.stellar.org
+HORIZON_TIMEOUT_MS=10000
 
 # ── Contract Addresses ────────────────────────────────────────────────────────
 # Source of truth for testnet IDs:

--- a/apps/api/src/horizon/horizon.service.spec.ts
+++ b/apps/api/src/horizon/horizon.service.spec.ts
@@ -16,7 +16,7 @@ import { CacheService } from '../cache/cache.service';
 import { IndexerCursorService } from '../indexer/indexer-cursor.service';
 import { PoolsService } from '../pools/pools.service';
 import { PriceService } from '../price/price.service';
-import { HorizonService } from './horizon.service';
+import { HorizonService, HorizonTimeoutError } from './horizon.service';
 
 // ── Stub factories ────────────────────────────────────────────────────────────
 
@@ -43,10 +43,14 @@ function buildEffectsChain(records: object[]) {
 
 function buildService(horizonServer: object) {
   const config = {
-    get: jest.fn().mockReturnValue({
-      horizonUrl: 'https://horizon.test',
-      poolContractId: 'GPOOL_CONTRACT',
-    }),
+    get: jest.fn((key: string) =>
+      key === 'stellar'
+        ? {
+            horizonUrl: 'https://horizon.test',
+            poolContractId: 'GPOOL_CONTRACT',
+          }
+        : undefined,
+    ),
   } as unknown as ConfigService;
   const priceService = { broadcastPrice: jest.fn() } as unknown as PriceService;
   const poolsService = {
@@ -356,6 +360,44 @@ describe('HorizonService — poller (Horizon mocked)', () => {
   });
 
   describe('error resilience', () => {
+    it('surfaces a typed timeout and releases the poller', async () => {
+      jest.useFakeTimers();
+      const { service } = buildService({});
+      (service as any).timeoutMs = 25;
+
+      const request = (service as any).withTimeout(new Promise(() => {}));
+      jest.advanceTimersByTime(25);
+
+      await expect(request).rejects.toBeInstanceOf(HorizonTimeoutError);
+      jest.useRealTimers();
+    });
+
+    it('backs off after failure and recovers on a later poll', async () => {
+      const call = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Horizon unavailable'))
+        .mockResolvedValueOnce({ records: [] });
+      const server = {
+        effects: () => ({
+          forAccount: () => ({
+            cursor: () => ({ order: () => ({ limit: () => ({ call }) }) }),
+          }),
+        }),
+      };
+      const { service } = buildService(server);
+      const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+
+      await (service as any).poll();
+      await (service as any).poll();
+      expect(call).toHaveBeenCalledTimes(1);
+
+      now.mockReturnValue(2_000);
+      await (service as any).poll();
+      expect(call).toHaveBeenCalledTimes(2);
+      expect((service as any).consecutiveFailures).toBe(0);
+      now.mockRestore();
+    });
+
     it('does not throw when Horizon.call() rejects — logs a warning instead', async () => {
       const server = {
         effects: () => ({

--- a/apps/api/src/horizon/horizon.service.ts
+++ b/apps/api/src/horizon/horizon.service.ts
@@ -26,6 +26,13 @@ import {
 } from '../indexer/queues';
 import { STELLAR_CONFIG_KEY, StellarConfig } from '../config/stellar.config';
 
+export class HorizonTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Horizon request timed out after ${timeoutMs}ms`);
+    this.name = 'HorizonTimeoutError';
+  }
+}
+
 @Injectable()
 export class HorizonService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(HorizonService.name);
@@ -35,6 +42,9 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
   private timer: NodeJS.Timeout | null = null;
   private polling = false;
   private stopped = false;
+  private readonly timeoutMs: number;
+  private consecutiveFailures = 0;
+  private nextAttemptAt = 0;
 
   constructor(
     private readonly config: ConfigService,
@@ -54,6 +64,13 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
     const stellarCfg = this.config.get<StellarConfig>(STELLAR_CONFIG_KEY)!;
     this.server = new Horizon.Server(stellarCfg.horizonUrl);
     this.contractId = stellarCfg.poolContractId;
+    const configuredTimeout = Number(
+      this.config.get<string>('HORIZON_TIMEOUT_MS') ?? 10_000,
+    );
+    this.timeoutMs =
+      Number.isFinite(configuredTimeout) && configuredTimeout > 0
+        ? configuredTimeout
+        : 10_000;
   }
 
   async onModuleInit() {
@@ -73,16 +90,20 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async poll(): Promise<void> {
-    if (this.polling || this.stopped) return;
+    if (this.polling || this.stopped || Date.now() < this.nextAttemptAt) return;
     this.polling = true;
     try {
-      const page = await this.server
-        .effects()
-        .forAccount(this.contractId)
-        .cursor(this.cursor)
-        .order('asc')
-        .limit(50)
-        .call();
+      const page = await this.withTimeout(
+        this.server
+          .effects()
+          .forAccount(this.contractId)
+          .cursor(this.cursor)
+          .order('asc')
+          .limit(50)
+          .call(),
+      );
+      this.consecutiveFailures = 0;
+      this.nextAttemptAt = 0;
 
       // Group records by ledger so we can batch-enqueue within each window.
       const byLedger = new Map<number | 'unknown', IndexerEffectRecord[]>();
@@ -121,10 +142,35 @@ export class HorizonService implements OnModuleInit, OnModuleDestroy {
         }
       }
     } catch (err) {
+      this.consecutiveFailures += 1;
+      const backoffMs = Math.min(
+        30_000,
+        1_000 * 2 ** (this.consecutiveFailures - 1),
+      );
+      this.nextAttemptAt = Date.now() + backoffMs;
       this.logger.warn(`Horizon poll error: ${(err as Error).message}`);
     } finally {
       this.polling = false;
     }
+  }
+
+  private withTimeout<T>(request: Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new HorizonTimeoutError(this.timeoutMs)),
+        this.timeoutMs,
+      );
+      request.then(
+        (value) => {
+          clearTimeout(timeout);
+          resolve(value);
+        },
+        (error: unknown) => {
+          clearTimeout(timeout);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

- enforce a configurable Horizon request timeout
- back off repeated polling failures with a capped circuit delay
- reset failure state after recovery and cover timeout/backoff behavior

## Related issue

- Closes #559

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Chore / refactor

## Checklist

- [ ] CI passes (lint + tests + build)
- [x] Self-reviewed the diff
- [x] Added or updated tests where relevant
- [x] Docs updated if needed