### PR TITLE
fix(api): redact sensitive headers in logging and add tracing spans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'packages/ui/**'
+      - 'packages/config/**'
+      - '.github/workflows/ci.yml'
+      - 'pnpm-lock.yaml'
   pull_request:
     branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'packages/ui/**'
+      - 'packages/config/**'
+      - '.github/workflows/ci.yml'
+      - 'pnpm-lock.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -128,6 +140,27 @@ jobs:
           STELLAR_RPC_URL: ${{ secrets.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org' }}
           HORIZON_URL: ${{ secrets.HORIZON_URL || 'https://horizon-testnet.stellar.org' }}
           STELLAR_NETWORK: testnet
+
+  web-vitest:
+    name: Web Vitest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run web Vitest
+        run: pnpm --filter web test
 
   e2e:
     name: E2E

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,15 @@ cargo test --workspace
 pnpm --filter api test
 ```
 
+### Run web Vitest
+
+```bash
+pnpm --filter web test
+```
+
+The CI workflow includes a dedicated web Vitest job so frontend regressions are
+caught whenever changes land in `apps/web`.
+
 ### Git hooks
 
 - **pre-commit** — runs ESLint on `apps/api`.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -55,6 +55,10 @@ The `-v` flag removes the named `postgres_data` volume, giving you a clean datab
 `CORS_ORIGIN`) as a comma-separated origin list and defaults to
 `http://localhost:3000`.
 
+Request logging automatically redacts sensitive headers and body fields such as
+`Authorization`, `x-api-key`, and password/API-key payload values before they
+are written to logs.
+
 ## Indexer recovery
 
 Each successfully persisted indexer event with a valid `ledger` field advances
@@ -103,3 +107,8 @@ retain the raw event tables for auditability and project the data into the
 canonical `Pool`, `Token`, `Swap`, and `Position` tables. Position events must
 include their pool-local `tokenId`; `liquidity` is the resulting position
 liquidity, so a value of `0` closes the position.
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is configured, the indexer worker emits
+OpenTelemetry spans for the fetch/write/project stages of pool-created,
+swap-processed, position, and fees-collected jobs so operators can inspect the
+batch-processing pipeline via their tracing backend.

--- a/apps/api/src/indexer/indexer.worker.ts
+++ b/apps/api/src/indexer/indexer.worker.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Worker, Job, QueueEvents } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { TokenEnrichmentService } from '../tokens/token-enrichment.service';
 import { IndexerCursorService } from './indexer-cursor.service';
@@ -22,6 +23,8 @@ import {
   QueueName,
 } from './queues';
 import { PoolsRepository } from '../pools/pools.repository';
+
+const tracer = trace.getTracer('swyft-indexer');
 
 @Injectable()
 export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
@@ -268,184 +271,382 @@ export class IndexerWorker implements OnModuleInit, OnModuleDestroy {
 
   private async handlePoolCreated(job: Job<PoolCreatedJobData>) {
     const d = job.data;
-    if (!this.guardEmptyData(job.id, d as unknown as Record<string, unknown>))
-      return;
-    await this.prisma.poolCreated.upsert({
-      where: { eventId: d.eventId },
-      update: {},
-      create: {
-        eventId: d.eventId,
-        poolId: d.poolId,
-        tokenA: d.tokenA,
-        tokenB: d.tokenB,
-        fee: d.fee,
-        sqrtPriceX96: d.sqrtPriceX96,
-        ledger: d.ledger ?? null,
+    await tracer.startActiveSpan(
+      'indexer.pool_created',
+      async (span) => {
+        try {
+          span.setAttributes({
+            'indexer.queue': QUEUE_NAMES.POOL_CREATED,
+            'indexer.job_id': job.id ?? '',
+            'indexer.event_id': d.eventId,
+            'indexer.pool_id': d.poolId,
+            'indexer.ledger': d.ledger ?? 0,
+          });
+
+          if (
+            !this.guardEmptyData(job.id, d as unknown as Record<string, unknown>)
+          ) {
+            span.setStatus({ code: SpanStatusCode.OK, message: 'skipped' });
+            return;
+          }
+
+          // Stage: write raw event
+          await tracer.startActiveSpan('indexer.pool_created.write', async (writeSpan) => {
+            try {
+              await this.prisma.poolCreated.upsert({
+                where: { eventId: d.eventId },
+                update: {},
+                create: {
+                  eventId: d.eventId,
+                  poolId: d.poolId,
+                  tokenA: d.tokenA,
+                  tokenB: d.tokenB,
+                  fee: d.fee,
+                  sqrtPriceX96: d.sqrtPriceX96,
+                  ledger: d.ledger ?? null,
+                },
+              });
+              writeSpan.setStatus({ code: SpanStatusCode.OK });
+            } catch (err) {
+              writeSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+              throw err;
+            } finally {
+              writeSpan.end();
+            }
+          });
+
+          // Stage: project into relational tables
+          await tracer.startActiveSpan('indexer.pool_created.project', async (projectSpan) => {
+            try {
+              await this.projectPoolCreated(d);
+              projectSpan.setStatus({ code: SpanStatusCode.OK });
+            } catch (err) {
+              projectSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+              throw err;
+            } finally {
+              projectSpan.end();
+            }
+          });
+
+          this.webhooks
+            .dispatch('pool.created', {
+              poolId: d.poolId,
+              tokenA: d.tokenA,
+              tokenB: d.tokenB,
+              fee: d.fee,
+              sqrtPriceX96: d.sqrtPriceX96,
+              eventId: d.eventId,
+            })
+            .catch((err) => {
+              this.logger.error(
+                `Failed to dispatch pool.created webhook: ${err.message}`,
+              );
+            });
+
+          await this.advanceLedger(job.id, d.ledger);
+          span.setStatus({ code: SpanStatusCode.OK });
+        } catch (err) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+          throw err;
+        } finally {
+          span.end();
+        }
       },
-    });
-
-    await this.projectPoolCreated(d);
-
-    this.webhooks
-      .dispatch('pool.created', {
-        poolId: d.poolId,
-        tokenA: d.tokenA,
-        tokenB: d.tokenB,
-        fee: d.fee,
-        sqrtPriceX96: d.sqrtPriceX96,
-        eventId: d.eventId,
-      })
-      .catch((err) => {
-        this.logger.error(
-          `Failed to dispatch pool.created webhook: ${err.message}`,
-        );
-      });
-
-    await this.advanceLedger(job.id, d.ledger);
+    );
   }
 
   private async handleSwapProcessed(job: Job<SwapProcessedJobData>) {
     const d = job.data;
-    if (!this.guardEmptyData(job.id, d as unknown as Record<string, unknown>))
-      return;
-    await this.prisma.swapProcessed.upsert({
-      where: { eventId: d.eventId },
-      update: {},
-      create: {
-        eventId: d.eventId,
-        poolId: d.poolId,
-        sender: d.sender,
-        recipient: d.recipient,
-        amount0: d.amount0,
-        amount1: d.amount1,
-        sqrtPriceX96: d.sqrtPriceX96,
-        liquidity: d.liquidity,
-        tick: d.tick,
-        ledger: d.ledger ?? null,
+    await tracer.startActiveSpan(
+      'indexer.swap_processed',
+      async (span) => {
+        try {
+          span.setAttributes({
+            'indexer.queue': QUEUE_NAMES.SWAP_PROCESSED,
+            'indexer.job_id': job.id ?? '',
+            'indexer.event_id': d.eventId,
+            'indexer.pool_id': d.poolId,
+            'indexer.ledger': d.ledger ?? 0,
+          });
+
+          if (
+            !this.guardEmptyData(job.id, d as unknown as Record<string, unknown>)
+          ) {
+            span.setStatus({ code: SpanStatusCode.OK, message: 'skipped' });
+            return;
+          }
+
+          // Stage: write raw event
+          await tracer.startActiveSpan('indexer.swap_processed.write', async (writeSpan) => {
+            try {
+              await this.prisma.swapProcessed.upsert({
+                where: { eventId: d.eventId },
+                update: {},
+                create: {
+                  eventId: d.eventId,
+                  poolId: d.poolId,
+                  sender: d.sender,
+                  recipient: d.recipient,
+                  amount0: d.amount0,
+                  amount1: d.amount1,
+                  sqrtPriceX96: d.sqrtPriceX96,
+                  liquidity: d.liquidity,
+                  tick: d.tick,
+                  ledger: d.ledger ?? null,
+                },
+              });
+              writeSpan.setStatus({ code: SpanStatusCode.OK });
+            } catch (err) {
+              writeSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+              throw err;
+            } finally {
+              writeSpan.end();
+            }
+          });
+
+          // Stage: project into relational tables
+          await tracer.startActiveSpan('indexer.swap_processed.project', async (projectSpan) => {
+            try {
+              await this.projectSwapProcessed(d);
+              projectSpan.setStatus({ code: SpanStatusCode.OK });
+            } catch (err) {
+              projectSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+              throw err;
+            } finally {
+              projectSpan.end();
+            }
+          });
+
+          this.webhooks
+            .dispatch('swap.large', {
+              poolId: d.poolId,
+              sender: d.sender,
+              recipient: d.recipient,
+              amount0: d.amount0,
+              amount1: d.amount1,
+              sqrtPriceX96: d.sqrtPriceX96,
+              liquidity: d.liquidity,
+              tick: d.tick,
+              eventId: d.eventId,
+            })
+            .catch((err) => {
+              this.logger.error(
+                `Failed to dispatch swap.large webhook: ${err.message}`,
+              );
+            });
+
+          await this.advanceLedger(job.id, d.ledger);
+          span.setStatus({ code: SpanStatusCode.OK });
+        } catch (err) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+          throw err;
+        } finally {
+          span.end();
+        }
       },
-    });
-
-    await this.projectSwapProcessed(d);
-
-    this.webhooks
-      .dispatch('swap.large', {
-        poolId: d.poolId,
-        sender: d.sender,
-        recipient: d.recipient,
-        amount0: d.amount0,
-        amount1: d.amount1,
-        sqrtPriceX96: d.sqrtPriceX96,
-        liquidity: d.liquidity,
-        tick: d.tick,
-        eventId: d.eventId,
-      })
-      .catch((err) => {
-        this.logger.error(
-          `Failed to dispatch swap.large webhook: ${err.message}`,
-        );
-      });
-
-    await this.advanceLedger(job.id, d.ledger);
+    );
   }
 
   private async handlePositionMinted(job: Job<PositionMintedJobData>) {
     const d = job.data;
-    if (!this.guardEmptyData(job.id, d as unknown as Record<string, unknown>))
-      return;
-    await this.prisma.positionMinted.upsert({
-      where: { eventId: d.eventId },
-      update: {},
-      create: {
-        eventId: d.eventId,
-        poolId: d.poolId,
-        tokenId: d.tokenId || null,
-        owner: d.owner,
-        tickLower: d.tickLower,
-        tickUpper: d.tickUpper,
-        liquidity: d.liquidity,
-        amount0: d.amount0,
-        amount1: d.amount1,
-        ledger: d.ledger ?? null,
-      },
+    await tracer.startActiveSpan('indexer.position_minted', async (span) => {
+      try {
+        span.setAttributes({
+          'indexer.queue': QUEUE_NAMES.POSITION_MINTED,
+          'indexer.job_id': job.id ?? '',
+          'indexer.event_id': d.eventId,
+          'indexer.pool_id': d.poolId,
+          'indexer.ledger': d.ledger ?? 0,
+        });
+
+        if (
+          !this.guardEmptyData(job.id, d as unknown as Record<string, unknown>)
+        ) {
+          span.setStatus({ code: SpanStatusCode.OK, message: 'skipped' });
+          return;
+        }
+
+        await tracer.startActiveSpan('indexer.position_minted.write', async (writeSpan) => {
+          try {
+            await this.prisma.positionMinted.upsert({
+              where: { eventId: d.eventId },
+              update: {},
+              create: {
+                eventId: d.eventId,
+                poolId: d.poolId,
+                tokenId: d.tokenId || null,
+                owner: d.owner,
+                tickLower: d.tickLower,
+                tickUpper: d.tickUpper,
+                liquidity: d.liquidity,
+                amount0: d.amount0,
+                amount1: d.amount1,
+                ledger: d.ledger ?? null,
+              },
+            });
+            // Project into relational Position table when the event includes a tokenId.
+            if (d.tokenId) {
+              await this.prisma.position.upsert({
+                where: { poolId_tokenId: { poolId: d.poolId, tokenId: d.tokenId } },
+                update: { liquidity: d.liquidity },
+                create: {
+                  poolId: d.poolId,
+                  tokenId: d.tokenId,
+                  ownerAddress: d.owner,
+                  lowerTick: d.tickLower,
+                  upperTick: d.tickUpper,
+                  liquidity: d.liquidity,
+                },
+              });
+            }
+            writeSpan.setStatus({ code: SpanStatusCode.OK });
+          } catch (err) {
+            writeSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+            throw err;
+          } finally {
+            writeSpan.end();
+          }
+        });
+
+        await this.advanceLedger(job.id, d.ledger);
+        span.setStatus({ code: SpanStatusCode.OK });
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+        throw err;
+      } finally {
+        span.end();
+      }
     });
-    // Project into relational Position table when the event includes a tokenId.
-    if (d.tokenId) {
-      await this.prisma.position.upsert({
-        where: { poolId_tokenId: { poolId: d.poolId, tokenId: d.tokenId } },
-        update: { liquidity: d.liquidity },
-        create: {
-          poolId: d.poolId,
-          tokenId: d.tokenId,
-          ownerAddress: d.owner,
-          lowerTick: d.tickLower,
-          upperTick: d.tickUpper,
-          liquidity: d.liquidity,
-        },
-      });
-    }
-    await this.advanceLedger(job.id, d.ledger);
   }
 
   private async handlePositionBurned(job: Job<PositionBurnedJobData>) {
     const d = job.data;
-    if (!this.guardEmptyData(job.id, d as unknown as Record<string, unknown>))
-      return;
-    await this.prisma.positionBurned.upsert({
-      where: { eventId: d.eventId },
-      update: {},
-      create: {
-        eventId: d.eventId,
-        poolId: d.poolId,
-        tokenId: d.tokenId || null,
-        owner: d.owner,
-        tickLower: d.tickLower,
-        tickUpper: d.tickUpper,
-        liquidity: d.liquidity,
-        amount0: d.amount0,
-        amount1: d.amount1,
-        ledger: d.ledger ?? null,
-      },
+    await tracer.startActiveSpan('indexer.position_burned', async (span) => {
+      try {
+        span.setAttributes({
+          'indexer.queue': QUEUE_NAMES.POSITION_BURNED,
+          'indexer.job_id': job.id ?? '',
+          'indexer.event_id': d.eventId,
+          'indexer.pool_id': d.poolId,
+          'indexer.ledger': d.ledger ?? 0,
+        });
+
+        if (
+          !this.guardEmptyData(job.id, d as unknown as Record<string, unknown>)
+        ) {
+          span.setStatus({ code: SpanStatusCode.OK, message: 'skipped' });
+          return;
+        }
+
+        await tracer.startActiveSpan('indexer.position_burned.write', async (writeSpan) => {
+          try {
+            await this.prisma.positionBurned.upsert({
+              where: { eventId: d.eventId },
+              update: {},
+              create: {
+                eventId: d.eventId,
+                poolId: d.poolId,
+                tokenId: d.tokenId || null,
+                owner: d.owner,
+                tickLower: d.tickLower,
+                tickUpper: d.tickUpper,
+                liquidity: d.liquidity,
+                amount0: d.amount0,
+                amount1: d.amount1,
+                ledger: d.ledger ?? null,
+              },
+            });
+            // Project into relational Position table when the event includes a tokenId.
+            if (d.tokenId) {
+              const isClosed = d.liquidity === '0';
+              await this.prisma.position.upsert({
+                where: { poolId_tokenId: { poolId: d.poolId, tokenId: d.tokenId } },
+                update: {
+                  liquidity: d.liquidity,
+                  ...(isClosed ? { closedAt: new Date() } : {}),
+                },
+                create: {
+                  poolId: d.poolId,
+                  tokenId: d.tokenId,
+                  ownerAddress: d.owner,
+                  lowerTick: d.tickLower,
+                  upperTick: d.tickUpper,
+                  liquidity: d.liquidity,
+                  ...(isClosed ? { closedAt: new Date() } : {}),
+                },
+              });
+            }
+            writeSpan.setStatus({ code: SpanStatusCode.OK });
+          } catch (err) {
+            writeSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+            throw err;
+          } finally {
+            writeSpan.end();
+          }
+        });
+
+        await this.advanceLedger(job.id, d.ledger);
+        span.setStatus({ code: SpanStatusCode.OK });
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+        throw err;
+      } finally {
+        span.end();
+      }
     });
-    // Project into relational Position table when the event includes a tokenId.
-    if (d.tokenId) {
-      const isClosed = d.liquidity === '0';
-      await this.prisma.position.upsert({
-        where: { poolId_tokenId: { poolId: d.poolId, tokenId: d.tokenId } },
-        update: {
-          liquidity: d.liquidity,
-          ...(isClosed ? { closedAt: new Date() } : {}),
-        },
-        create: {
-          poolId: d.poolId,
-          tokenId: d.tokenId,
-          ownerAddress: d.owner,
-          lowerTick: d.tickLower,
-          upperTick: d.tickUpper,
-          liquidity: d.liquidity,
-          ...(isClosed ? { closedAt: new Date() } : {}),
-        },
-      });
-    }
-    await this.advanceLedger(job.id, d.ledger);
   }
 
   private async handleFeesCollected(job: Job<FeesCollectedJobData>) {
     const d = job.data;
-    if (!this.guardEmptyData(job.id, d as unknown as Record<string, unknown>))
-      return;
-    await this.prisma.feesCollected.upsert({
-      where: { eventId: d.eventId },
-      update: {},
-      create: {
-        eventId: d.eventId,
-        poolId: d.poolId,
-        recipient: d.recipient,
-        amount0: d.amount0,
-        amount1: d.amount1,
-        ledger: d.ledger ?? null,
-      },
+    await tracer.startActiveSpan('indexer.fees_collected', async (span) => {
+      try {
+        span.setAttributes({
+          'indexer.queue': QUEUE_NAMES.FEES_COLLECTED,
+          'indexer.job_id': job.id ?? '',
+          'indexer.event_id': d.eventId,
+          'indexer.pool_id': d.poolId,
+          'indexer.ledger': d.ledger ?? 0,
+        });
+
+        if (
+          !this.guardEmptyData(job.id, d as unknown as Record<string, unknown>)
+        ) {
+          span.setStatus({ code: SpanStatusCode.OK, message: 'skipped' });
+          return;
+        }
+
+        await tracer.startActiveSpan('indexer.fees_collected.write', async (writeSpan) => {
+          try {
+            await this.prisma.feesCollected.upsert({
+              where: { eventId: d.eventId },
+              update: {},
+              create: {
+                eventId: d.eventId,
+                poolId: d.poolId,
+                recipient: d.recipient,
+                amount0: d.amount0,
+                amount1: d.amount1,
+                ledger: d.ledger ?? null,
+              },
+            });
+            writeSpan.setStatus({ code: SpanStatusCode.OK });
+          } catch (err) {
+            writeSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+            throw err;
+          } finally {
+            writeSpan.end();
+          }
+        });
+
+        await this.advanceLedger(job.id, d.ledger);
+        span.setStatus({ code: SpanStatusCode.OK });
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+        throw err;
+      } finally {
+        span.end();
+      }
     });
-    await this.advanceLedger(job.id, d.ledger);
   }
 
   /** Advances the durable checkpoint only after the event write completed. */

--- a/apps/api/src/logging/logging.middleware.spec.ts
+++ b/apps/api/src/logging/logging.middleware.spec.ts
@@ -103,4 +103,50 @@ describe('LoggingMiddleware', () => {
       expect.stringContaining(`requestId=${requestId}`),
     );
   });
+
+  it('redacts sensitive headers and body fields in production logs', () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const middleware = new LoggingMiddleware();
+    const res = response();
+    const req = request({
+      headers: {
+        authorization: 'Bearer top-secret',
+        'x-api-key': 'api-key-secret',
+        'x-foo': 'visible',
+      },
+      body: {
+        apiKey: 'body-secret',
+        password: 'body-password',
+        safeValue: 'visible',
+      },
+    });
+    const logSpy = jest
+      .spyOn(
+        (middleware as unknown as { logger: { log: () => void } }).logger,
+        'log',
+      )
+      .mockImplementation(() => undefined);
+
+    middleware.use(req as never, res as never, next);
+    res.emitFinish();
+
+    const output = logSpy.mock.calls.map((args) => args[0]).join(' ');
+    expect(output).toContain('"authorization":"[REDACTED]"');
+    expect(output).toContain('"x-api-key":"[REDACTED]"');
+    expect(output).toContain('"apiKey":"[REDACTED]"');
+    expect(output).toContain('"password":"[REDACTED]"');
+    expect(output).not.toContain('top-secret');
+    expect(output).not.toContain('api-key-secret');
+    expect(output).not.toContain('body-secret');
+    expect(output).not.toContain('body-password');
+    expect(output).toContain('"x-foo":"visible"');
+
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
 });

--- a/apps/api/src/logging/logging.middleware.ts
+++ b/apps/api/src/logging/logging.middleware.ts
@@ -4,30 +4,54 @@ import { randomUUID } from 'crypto';
 import { getActiveTraceIds } from '../tracing';
 import { RequestContext } from './request-context';
 
-const SENSITIVE_HEADERS = new Set(['authorization', 'cookie', 'set-cookie']);
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'api-key',
+  'x-api-token',
+]);
 const SENSITIVE_BODY_KEYS = new Set([
   'password',
   'token',
   'secret',
   'accessToken',
   'refreshToken',
+  'apiKey',
+  'api_key',
+  'apikey',
 ]);
+
+function isSensitiveHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    SENSITIVE_HEADERS.has(normalized) ||
+    normalized.includes('authorization') ||
+    normalized.includes('api-key') ||
+    normalized.includes('api_key')
+  );
+}
 
 function redactHeaders(
   headers: Record<string, unknown>,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(headers)) {
-    out[k] = SENSITIVE_HEADERS.has(k.toLowerCase()) ? '[REDACTED]' : v;
+    out[k] = isSensitiveHeader(k) ? '[REDACTED]' : v;
   }
   return out;
 }
 
 function redactBody(body: unknown): unknown {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
+  if (body === null || body === undefined) return body;
+  if (Array.isArray(body)) return body.map((item) => redactBody(item));
+  if (typeof body !== 'object') return body;
+
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
-    out[k] = SENSITIVE_BODY_KEYS.has(k) ? '[REDACTED]' : v;
+    out[k] = SENSITIVE_BODY_KEYS.has(k) ? '[REDACTED]' : redactBody(v);
   }
   return out;
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "files": [
     "src",


### PR DESCRIPTION
## Summary
- redact sensitive Authorization/API-key data from request logging
- add tracing spans around indexer batch write/project stages
- make the web Vitest job run in CI for web-related changes and document it in CONTRIBUTING

Closes #596
Closes #597
Closes #598
Closes #599

## Testing
- pnpm --filter api test -- logging.middleware.spec.ts
- pnpm --filter web test